### PR TITLE
Added support for custom http headers in the appender.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ In your `logback.xml`:
                     <value>%logger</value>
                 </property>
             </properties>
+            <headers>
+                <header>
+                    <name>Content-Type</name>
+                    <value>text/plain</value>
+                </header>
+            </headers>
         </appender>
         
         <root level="info">

--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchAppender.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchAppender.java
@@ -1,13 +1,14 @@
 package com.internetitem.logback.elasticsearch;
 
-import ch.qos.logback.core.UnsynchronizedAppenderBase;
-import com.internetitem.logback.elasticsearch.config.ElasticsearchProperties;
-import com.internetitem.logback.elasticsearch.config.Settings;
-import com.internetitem.logback.elasticsearch.util.ErrorReporter;
-
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import com.internetitem.logback.elasticsearch.config.ElasticsearchProperties;
+import com.internetitem.logback.elasticsearch.config.HttpRequestHeaders;
+import com.internetitem.logback.elasticsearch.config.Settings;
+import com.internetitem.logback.elasticsearch.util.ErrorReporter;
 
 public abstract class AbstractElasticsearchAppender<T> extends UnsynchronizedAppenderBase<T> {
 
@@ -15,9 +16,11 @@ public abstract class AbstractElasticsearchAppender<T> extends UnsynchronizedApp
     protected ElasticsearchProperties elasticsearchProperties;
     protected AbstractElasticsearchPublisher<T> publisher;
     protected ErrorReporter errorReporter;
+	protected HttpRequestHeaders headers;
 
 	public AbstractElasticsearchAppender() {
 		this.settings = new Settings();
+		this.headers = new HttpRequestHeaders();
 	}
 
     public AbstractElasticsearchAppender(Settings settings) {
@@ -115,5 +118,8 @@ public abstract class AbstractElasticsearchAppender<T> extends UnsynchronizedApp
 		settings.setErrorLoggerName(logger);
 	}
 
+	public void setHeaders(HttpRequestHeaders httpRequestHeaders) {
+		this.headers = httpRequestHeaders;
+	}
 
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/AccessElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AccessElasticsearchPublisher.java
@@ -1,21 +1,22 @@
 package com.internetitem.logback.elasticsearch;
 
+import java.io.IOException;
+
 import ch.qos.logback.access.spi.IAccessEvent;
 import ch.qos.logback.core.Context;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.internetitem.logback.elasticsearch.config.ElasticsearchProperties;
+import com.internetitem.logback.elasticsearch.config.HttpRequestHeaders;
 import com.internetitem.logback.elasticsearch.config.Property;
 import com.internetitem.logback.elasticsearch.config.Settings;
 import com.internetitem.logback.elasticsearch.util.AbstractPropertyAndEncoder;
 import com.internetitem.logback.elasticsearch.util.AccessPropertyAndEncoder;
 import com.internetitem.logback.elasticsearch.util.ErrorReporter;
 
-import java.io.IOException;
-
 public class AccessElasticsearchPublisher extends AbstractElasticsearchPublisher<IAccessEvent> {
 
-	public AccessElasticsearchPublisher(Context context, ErrorReporter errorReporter, Settings settings, ElasticsearchProperties properties) throws IOException {
-		super(context, errorReporter, settings, properties);
+	public AccessElasticsearchPublisher(Context context, ErrorReporter errorReporter, Settings settings, ElasticsearchProperties properties, HttpRequestHeaders httpRequestHeaders) throws IOException {
+		super(context, errorReporter, settings, properties, httpRequestHeaders);
 	}
 
 	@Override

--- a/src/main/java/com/internetitem/logback/elasticsearch/ClassicElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/ClassicElasticsearchPublisher.java
@@ -1,21 +1,22 @@
 package com.internetitem.logback.elasticsearch;
 
+import java.io.IOException;
+
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Context;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.internetitem.logback.elasticsearch.config.ElasticsearchProperties;
+import com.internetitem.logback.elasticsearch.config.HttpRequestHeaders;
 import com.internetitem.logback.elasticsearch.config.Property;
 import com.internetitem.logback.elasticsearch.config.Settings;
 import com.internetitem.logback.elasticsearch.util.AbstractPropertyAndEncoder;
 import com.internetitem.logback.elasticsearch.util.ClassicPropertyAndEncoder;
 import com.internetitem.logback.elasticsearch.util.ErrorReporter;
 
-import java.io.IOException;
-
 public class ClassicElasticsearchPublisher extends AbstractElasticsearchPublisher<ILoggingEvent> {
 
-	public ClassicElasticsearchPublisher(Context context, ErrorReporter errorReporter, Settings settings, ElasticsearchProperties properties) throws IOException {
-		super(context, errorReporter, settings, properties);
+	public ClassicElasticsearchPublisher(Context context, ErrorReporter errorReporter, Settings settings, ElasticsearchProperties properties, HttpRequestHeaders headers) throws IOException {
+		super(context, errorReporter, settings, properties, headers);
 	}
 
 	@Override

--- a/src/main/java/com/internetitem/logback/elasticsearch/ElasticsearchAccessAppender.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/ElasticsearchAccessAppender.java
@@ -1,9 +1,9 @@
 package com.internetitem.logback.elasticsearch;
 
+import java.io.IOException;
+
 import ch.qos.logback.access.spi.IAccessEvent;
 import com.internetitem.logback.elasticsearch.config.Settings;
-
-import java.io.IOException;
 
 public class ElasticsearchAccessAppender extends AbstractElasticsearchAppender<IAccessEvent> {
 
@@ -21,7 +21,7 @@ public class ElasticsearchAccessAppender extends AbstractElasticsearchAppender<I
     }
 
     protected AccessElasticsearchPublisher buildElasticsearchPublisher() throws IOException {
-        return new AccessElasticsearchPublisher(getContext(), errorReporter, settings, elasticsearchProperties);
+        return new AccessElasticsearchPublisher(getContext(), errorReporter, settings, elasticsearchProperties, headers);
     }
 
 

--- a/src/main/java/com/internetitem/logback/elasticsearch/ElasticsearchAppender.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/ElasticsearchAppender.java
@@ -1,9 +1,9 @@
 package com.internetitem.logback.elasticsearch;
 
+import java.io.IOException;
+
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.internetitem.logback.elasticsearch.config.Settings;
-
-import java.io.IOException;
 
 public class ElasticsearchAppender extends AbstractElasticsearchAppender<ILoggingEvent> {
 
@@ -38,7 +38,7 @@ public class ElasticsearchAppender extends AbstractElasticsearchAppender<ILoggin
     }
 
     protected ClassicElasticsearchPublisher buildElasticsearchPublisher() throws IOException {
-        return new ClassicElasticsearchPublisher(getContext(), errorReporter, settings, elasticsearchProperties);
+        return new ClassicElasticsearchPublisher(getContext(), errorReporter, settings, elasticsearchProperties, headers);
     }
 
 

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/HttpRequestHeader.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/HttpRequestHeader.java
@@ -1,0 +1,26 @@
+package com.internetitem.logback.elasticsearch.config;
+
+/**
+ * A key value pair for the http header.
+ */
+public class HttpRequestHeader {
+
+    private String name;
+    private String value;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/HttpRequestHeaders.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/HttpRequestHeaders.java
@@ -1,0 +1,20 @@
+package com.internetitem.logback.elasticsearch.config;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * A container for the headers which will be sent to elasticsearch.
+ */
+public class HttpRequestHeaders {
+
+    private List<HttpRequestHeader> headers = new LinkedList<HttpRequestHeader>();
+
+    public List<HttpRequestHeader> getHeaders() {
+        return headers;
+    }
+
+    public void addHeader(HttpRequestHeader header) {
+        this.headers.add(header);
+    }
+}


### PR DESCRIPTION
Hello, I needed to add support for custom http headers to all requests sent to Elasticsearch. Sending you my patch which is pretty basic.

Usage in logback.xml:

```xml
<headers>
   <header>
       <name>Content-Type</name>
       <value>application/json</name>
   <header>
</headers>
```