### PR TITLE
Adding support for messages in raw JSON format.

### DIFF
--- a/src/main/java/com/internetitem/logback/elasticsearch/ClassicElasticsearchJsonRawMessagePublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/ClassicElasticsearchJsonRawMessagePublisher.java
@@ -1,0 +1,33 @@
+package com.internetitem.logback.elasticsearch;
+
+import java.io.IOException;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Context;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.internetitem.logback.elasticsearch.config.ElasticsearchProperties;
+import com.internetitem.logback.elasticsearch.config.HttpRequestHeaders;
+import com.internetitem.logback.elasticsearch.config.Property;
+import com.internetitem.logback.elasticsearch.config.Settings;
+import com.internetitem.logback.elasticsearch.util.AbstractPropertyAndEncoder;
+import com.internetitem.logback.elasticsearch.util.ClassicPropertyAndEncoder;
+import com.internetitem.logback.elasticsearch.util.ErrorReporter;
+
+public class ClassicElasticsearchJsonRawMessagePublisher extends AbstractElasticsearchPublisher<ILoggingEvent> {
+
+	public ClassicElasticsearchJsonRawMessagePublisher(Context context, ErrorReporter errorReporter, Settings settings, ElasticsearchProperties properties, HttpRequestHeaders headers) throws IOException {
+		super(context, errorReporter, settings, properties, headers);
+	}
+
+	@Override
+	protected AbstractPropertyAndEncoder<ILoggingEvent> buildPropertyAndEncoder(Context context, Property property) {
+		return new ClassicPropertyAndEncoder(property, context);
+	}
+
+	@Override
+	protected void serializeCommonFields(JsonGenerator gen, ILoggingEvent event) throws IOException {
+		gen.writeObjectField("@timestamp", getTimestamp(event.getTimeStamp()));
+                gen.writeFieldName("message");
+                gen.writeRawValue(event.getFormattedMessage());
+	}
+}

--- a/src/main/java/com/internetitem/logback/elasticsearch/ElasticsearchJsonRawMessageAppender.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/ElasticsearchJsonRawMessageAppender.java
@@ -1,0 +1,45 @@
+package com.internetitem.logback.elasticsearch;
+
+import java.io.IOException;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.internetitem.logback.elasticsearch.config.Settings;
+
+public class ElasticsearchJsonRawMessageAppender extends AbstractElasticsearchAppender<ILoggingEvent> {
+
+    public ElasticsearchJsonRawMessageAppender() {
+    }
+
+    public ElasticsearchJsonRawMessageAppender(Settings settings) {
+        super(settings);
+    }
+
+    @Override
+    protected void appendInternal(ILoggingEvent eventObject) {
+
+        String targetLogger = eventObject.getLoggerName();
+
+        String loggerName = settings.getLoggerName();
+        if (loggerName != null && loggerName.equals(targetLogger)) {
+            return;
+        }
+
+        String errorLoggerName = settings.getErrorLoggerName();
+        if (errorLoggerName != null && errorLoggerName.equals(targetLogger)) {
+            return;
+        }
+
+        eventObject.prepareForDeferredProcessing();
+        if (settings.isIncludeCallerData()) {
+            eventObject.getCallerData();
+        }
+
+        publishEvent(eventObject);
+    }
+
+    protected ClassicElasticsearchJsonRawMessagePublisher buildElasticsearchPublisher() throws IOException {
+        return new ClassicElasticsearchJsonRawMessagePublisher(getContext(), errorReporter, settings, elasticsearchProperties, headers);
+    }
+
+
+}


### PR DESCRIPTION
An application I am working with creates structured log messages in JSON format. Unfortunately, if I use the classic appender, message inner JSON gets escaped (since it is treated as a string value). 

To work around the issue, I propose to create a separate publisher and an appender that treats the message as raw JSON. 