### PR TITLE
Reducing logging (removing full stacktrace) for connectivity errors

### DIFF
--- a/src/main/java/com/internetitem/logback/elasticsearch/ElasticsearchOutputAggregator.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/ElasticsearchOutputAggregator.java
@@ -51,9 +51,9 @@ public class ElasticsearchOutputAggregator extends Writer {
 		for (SafeWriter writer : writers) {
 			try {
 				writer.sendData();
-			} catch (Exception e) {
+			} catch (IOException e) {
 				success = false;
-				errorReporter.logError("Failed to send events to Elasticsearch: " + e.getMessage(), e);
+				errorReporter.logWarning("Failed to send events to Elasticsearch: " + e.getMessage());
 				if (settings.isErrorsToStderr()) {
 					System.err.println("[" + new Date().toString() + "] Failed to send events to Elasticsearch: " + e.getMessage());
 				}


### PR DESCRIPTION
This is a proposal to reduce the severity level of ElasticSearch connectivity errors, thus eliminating the full stacktrace from the logs. Connectivity errors have very static stacktraces, and moreover - they are subject for automatic re-delivery attempts, so it does not make sense to me to log them in details. 

Also reducing the exception handling scope to IOException, for code clarity purposes.