### PR TITLE
Enable Basic Authentication & Ignore HTTPS certificates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,12 @@
             <version>1.10.8</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/internetitem/logback/elasticsearch/writer/ElasticsearchWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/writer/ElasticsearchWriter.java
@@ -1,17 +1,5 @@
 package com.internetitem.logback.elasticsearch.writer;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.util.Collection;
-import java.util.Collections;
-
 import com.internetitem.logback.elasticsearch.config.HttpRequestHeader;
 import com.internetitem.logback.elasticsearch.config.HttpRequestHeaders;
 import com.internetitem.logback.elasticsearch.config.Settings;
@@ -23,6 +11,17 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.Collections;
 
 public class ElasticsearchWriter implements SafeWriter {
 
@@ -67,20 +66,20 @@ public class ElasticsearchWriter implements SafeWriter {
 		URL url = settings.getUrl();
 
 		if ("https".equals(url.getProtocol().toLowerCase())){
+			// if HTTPS then ignore SSL certificates
 
 			trustAllHosts();
-
 			HttpsURLConnection httpsURLConnection = (HttpsURLConnection) url.openConnection();
 			httpsURLConnection.setHostnameVerifier(SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
-
-			if (url.getUserInfo() != null) {
-				String basicAuth = "Basic " + new String(new Base64().encode(url.getUserInfo().getBytes()));
-				httpsURLConnection.setRequestProperty("Authorization", basicAuth);
-			}
-
 			urlConnection = httpsURLConnection;
 		} else {
 			urlConnection = (HttpURLConnection)(url.openConnection());
+		}
+
+		// add basic authentication if present
+		if (url.getUserInfo() != null) {
+			String basicAuth = "Basic " + new String(new Base64().encode(url.getUserInfo().getBytes()));
+			urlConnection.setRequestProperty("Authorization", basicAuth);
 		}
 
 		try {


### PR DESCRIPTION
Added following abilities: work with elasticsearch with basic authentication enables and communicate with any https server (ignore ssl validation)

This change was initially reported here https://github.com/internetitem/logback-elasticsearch-appender/issues/6
