### PR TITLE
Add generic authentication extension point

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Configuration Reference
  * `loggerName` (optional): If set, raw ES-formatted log data will be sent to this logger
  * `errorLoggerName` (optional): If set, any internal errors or problems will be logged to this logger
  * `rawJsonMessage` (optional, default false): If set to `true`, the log message is interpreted as pre-formatted raw JSON message. 
+ * `authentication` (optional, default null): If set, adds the ability to add extra headers to the bulk requests (to pass authentication, for example). See below.
 
 The fields `@timestamp` and `message` are always sent and can not currently be configured. Additional fields can be sent by adding `<property>` elements to the `<properties>` set.
 
@@ -119,3 +120,10 @@ Included is also an Elasticsearch appender for Logback Access. The configuration
  * The Appender class name is `com.internetitem.logback.elasticsearch.ElasticsearchAccessAppender`
  * The `value` for each `property` uses the [Logback Access conversion words](http://logback.qos.ch/manual/layouts.html#logback-access).
 
+Authentication
+==============
+
+An example of using the optional authentication:
+```
+    settings.setAuthentication(new BasicAuthentication())
+```

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,15 @@
                     <releaseProfiles>release</releaseProfiles>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/Authentication.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/Authentication.java
@@ -1,0 +1,13 @@
+package com.internetitem.logback.elasticsearch.config;
+
+import java.net.HttpURLConnection;
+
+public interface Authentication {
+    /**
+     * Modify the given urlConnection for whatever authentication scheme is used.
+     *
+     * @param urlConnection the connection to the server
+     * @param body the message being sent
+     */
+    void addAuth(HttpURLConnection urlConnection, String body);
+}

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/BasicAuthAuthentication.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/BasicAuthAuthentication.java
@@ -1,0 +1,14 @@
+package com.internetitem.logback.elasticsearch.config;
+
+import java.net.HttpURLConnection;
+import java.util.Base64;
+
+public class BasicAuthAuthentication implements Authentication {
+    public void addAuth(HttpURLConnection urlConnection, String body) {
+        String userInfo = urlConnection.getURL().getUserInfo();
+        if (userInfo != null) {
+            String basicAuth = "Basic " + new String(Base64.getEncoder().encode(userInfo.getBytes()));
+            urlConnection.setRequestProperty("Authorization", basicAuth);
+        }
+    }
+}

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/BasicAuthentication.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/BasicAuthentication.java
@@ -1,13 +1,13 @@
 package com.internetitem.logback.elasticsearch.config;
 
+import javax.xml.bind.DatatypeConverter;
 import java.net.HttpURLConnection;
-import java.util.Base64;
 
-public class BasicAuthAuthentication implements Authentication {
+public class BasicAuthentication implements Authentication {
     public void addAuth(HttpURLConnection urlConnection, String body) {
         String userInfo = urlConnection.getURL().getUserInfo();
         if (userInfo != null) {
-            String basicAuth = "Basic " + new String(Base64.getEncoder().encode(userInfo.getBytes()));
+            String basicAuth = "Basic " + DatatypeConverter.printBase64Binary(userInfo.getBytes());
             urlConnection.setRequestProperty("Authorization", basicAuth);
         }
     }

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/Settings.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/Settings.java
@@ -20,6 +20,7 @@ public class Settings {
 	private boolean includeCallerData;
         private boolean rawJsonMessage;
 	private int maxQueueSize = 100 * 1024 * 1024;
+	private Authentication authentication;
 
 	public String getIndex() {
 		return index;
@@ -134,5 +135,13 @@ public class Settings {
 
 	public void setRawJsonMessage(boolean rawJsonMessage) {
 		this.rawJsonMessage = rawJsonMessage;
+	}
+
+	public Authentication getAuthentication() {
+		return authentication;
+	}
+
+	public void setAuthentication(Authentication authentication) {
+		this.authentication = authentication;
 	}
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/writer/ElasticsearchWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/writer/ElasticsearchWriter.java
@@ -60,13 +60,20 @@ public class ElasticsearchWriter implements SafeWriter {
 			urlConnection.setConnectTimeout(settings.getConnectTimeout());
 			urlConnection.setRequestMethod("POST");
 
+			String body = sendBuffer.toString();
+
 			if (!headerList.isEmpty()) {
 				for(HttpRequestHeader header: headerList) {
 					urlConnection.setRequestProperty(header.getName(), header.getValue());
 				}
 			}
+
+			if (settings.getAuthentication() != null) {
+				settings.getAuthentication().addAuth(urlConnection, body);
+			}
+
 			Writer writer = new OutputStreamWriter(urlConnection.getOutputStream(), "UTF-8");
-			writer.write(sendBuffer.toString());
+			writer.write(body);
 			writer.flush();
 			writer.close();
 


### PR DESCRIPTION
Note - we needed the same auth feature as PR https://github.com/internetitem/logback-elasticsearch-appender/pull/10 but for Amazon hosted elastic search (proprietary so can't be included).