### PR TITLE
Replace JAXB dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ In your `logback.xml`:
             <readTimeout>30000</readTimeout> <!-- optional (in ms, default 30000) -->
             <sleepTime>250</sleepTime> <!-- optional (in ms, default 250) -->
             <rawJsonMessage>false</rawJsonMessage> <!-- optional (default false) -->
+            <includeMdc>false</includeMdc> <!-- optional (default false) -->
             <authentication class="com.internetitem.logback.elasticsearch.config.BasicAuthentication" /> <!-- optional -->
             <properties>
                 <property>
@@ -104,7 +105,8 @@ Configuration Reference
  * `maxQueueSize` (optional, default 104,857,600 = 200MB): Maximum size (in characters) of the send buffer. After this point, *logs will be dropped*. This should only happen if Elasticsearch is down, but this is a self-protection mechanism to ensure that the logging system doesn't cause the main process to run out of memory. Note that this maximum is approximate; once the maximum is hit, no new logs will be accepted until it shrinks, but any logs already accepted to be processed will still be added to the buffer
  * `loggerName` (optional): If set, raw ES-formatted log data will be sent to this logger
  * `errorLoggerName` (optional): If set, any internal errors or problems will be logged to this logger
- * `rawJsonMessage` (optional, default false): If set to `true`, the log message is interpreted as pre-formatted raw JSON message. 
+ * `rawJsonMessage` (optional, default false): If set to `true`, the log message is interpreted as pre-formatted raw JSON message.
+ * `includeMdc` (optional, default false): If set to `true`, then all [MDC](http://www.slf4j.org/api/org/slf4j/MDC.html) values will be mapped to properties on the JSON payload.
  * `authentication` (optional): Add the ability to send authentication headers (see below)
 
 The fields `@timestamp` and `message` are always sent and can not currently be configured. Additional fields can be sent by adding `<property>` elements to the `<properties>` set.
@@ -127,4 +129,3 @@ Included is also an Elasticsearch appender for Logback Access. The configuration
 
  * The Appender class name is `com.internetitem.logback.elasticsearch.ElasticsearchAccessAppender`
  * The `value` for each `property` uses the [Logback Access conversion words](http://logback.qos.ch/manual/layouts.html#logback-access).
-

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In your `pom.xml` (or equivalent), add:
      <dependency>
         <groupId>com.internetitem</groupId>
         <artifactId>logback-elasticsearch-appender</artifactId>
-        <version>1.4</version>
+        <version>1.5</version>
      </dependency>
 
 In your `logback.xml`:

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.internetitem</groupId>
     <artifactId>logback-elasticsearch-appender</artifactId>
-    <version>1.5</version>
+    <version>1.6-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Logback Elasticsearch Appender</name>
@@ -28,7 +28,7 @@
         <connection>scm:git:https://github.com/internetitem/logback-elasticsearch-appender.git</connection>
         <developerConnection>scm:git:https://github.com/internetitem/logback-elasticsearch-appender.git</developerConnection>
         <url>https://github.com/internetitem/logback-elasticsearch-appender</url>
-        <tag>v1.5</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.internetitem</groupId>
     <artifactId>logback-elasticsearch-appender</artifactId>
-    <version>1.5-SNAPSHOT</version>
+    <version>1.5</version>
     <packaging>jar</packaging>
 
     <name>Logback Elasticsearch Appender</name>
@@ -28,7 +28,7 @@
         <connection>scm:git:https://github.com/internetitem/logback-elasticsearch-appender.git</connection>
         <developerConnection>scm:git:https://github.com/internetitem/logback-elasticsearch-appender.git</developerConnection>
         <url>https://github.com/internetitem/logback-elasticsearch-appender</url>
-        <tag>HEAD</tag>
+        <tag>v1.5</tag>
     </scm>
 
     <developers>

--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchAppender.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchAppender.java
@@ -123,9 +123,13 @@ public abstract class AbstractElasticsearchAppender<T> extends UnsynchronizedApp
 		this.headers = httpRequestHeaders;
 	}
 
-        public void setRawJsonMessage(boolean rawJsonMessage) {
-                settings.setRawJsonMessage(rawJsonMessage);
-        }
+	public void setRawJsonMessage(boolean rawJsonMessage) {
+			settings.setRawJsonMessage(rawJsonMessage);
+	}
+
+	public void setIncludeMdc(boolean includeMdc) {
+		settings.setIncludeMdc(includeMdc);
+	}
 
     public void setAuthentication(Authentication auth) {
         settings.setAuthentication(auth);

--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
@@ -1,13 +1,5 @@
 package com.internetitem.logback.elasticsearch;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.xml.bind.DatatypeConverter;
-
 import ch.qos.logback.core.Context;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -21,11 +13,20 @@ import com.internetitem.logback.elasticsearch.writer.ElasticsearchWriter;
 import com.internetitem.logback.elasticsearch.writer.LoggerWriter;
 import com.internetitem.logback.elasticsearch.writer.StdErrWriter;
 
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
 public abstract class AbstractElasticsearchPublisher<T> implements Runnable {
 
 	private static final AtomicInteger THREAD_COUNTER = new AtomicInteger(1);
+	private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.ssZ");
 
 	public static final String THREAD_NAME_PREFIX = "es-writer-";
+
 
 	private volatile List<T> events;
 	private ElasticsearchOutputAggregator outputAggregator;
@@ -190,9 +191,7 @@ public abstract class AbstractElasticsearchPublisher<T> implements Runnable {
 	protected abstract void serializeCommonFields(JsonGenerator gen, T event) throws IOException;
 
 	protected static String getTimestamp(long timestamp) {
-		Calendar cal = Calendar.getInstance();
-		cal.setTimeInMillis(timestamp);
-		return DatatypeConverter.printDateTime(cal);
+		return DATE_FORMAT.format(new Date(timestamp));
 	}
 
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
@@ -14,6 +14,7 @@ import com.internetitem.logback.elasticsearch.writer.LoggerWriter;
 import com.internetitem.logback.elasticsearch.writer.StdErrWriter;
 
 import java.io.IOException;
+import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -23,7 +24,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 public abstract class AbstractElasticsearchPublisher<T> implements Runnable {
 
 	private static final AtomicInteger THREAD_COUNTER = new AtomicInteger(1);
-	private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.ssZ");
+	private static final ThreadLocal<DateFormat> DATE_FORMAT = new ThreadLocal<DateFormat> () {
+		@Override
+		protected DateFormat initialValue() {
+			return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.ssZ");
+		}
+	};
 
 	public static final String THREAD_NAME_PREFIX = "es-writer-";
 
@@ -191,7 +197,7 @@ public abstract class AbstractElasticsearchPublisher<T> implements Runnable {
 	protected abstract void serializeCommonFields(JsonGenerator gen, T event) throws IOException;
 
 	protected static String getTimestamp(long timestamp) {
-		return DATE_FORMAT.format(new Date(timestamp));
+		return DATE_FORMAT.get().format(new Date(timestamp));
 	}
 
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/ClassicElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/ClassicElasticsearchPublisher.java
@@ -1,6 +1,7 @@
 package com.internetitem.logback.elasticsearch;
 
 import java.io.IOException;
+import java.util.Map;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Context;
@@ -15,24 +16,30 @@ import com.internetitem.logback.elasticsearch.util.ErrorReporter;
 
 public class ClassicElasticsearchPublisher extends AbstractElasticsearchPublisher<ILoggingEvent> {
 
-	public ClassicElasticsearchPublisher(Context context, ErrorReporter errorReporter, Settings settings, ElasticsearchProperties properties, HttpRequestHeaders headers) throws IOException {
-		super(context, errorReporter, settings, properties, headers);
-	}
+    public ClassicElasticsearchPublisher(Context context, ErrorReporter errorReporter, Settings settings, ElasticsearchProperties properties, HttpRequestHeaders headers) throws IOException {
+        super(context, errorReporter, settings, properties, headers);
+    }
 
-	@Override
-	protected AbstractPropertyAndEncoder<ILoggingEvent> buildPropertyAndEncoder(Context context, Property property) {
-		return new ClassicPropertyAndEncoder(property, context);
-	}
+    @Override
+    protected AbstractPropertyAndEncoder<ILoggingEvent> buildPropertyAndEncoder(Context context, Property property) {
+        return new ClassicPropertyAndEncoder(property, context);
+    }
 
-	@Override
-	protected void serializeCommonFields(JsonGenerator gen, ILoggingEvent event) throws IOException {
-		gen.writeObjectField("@timestamp", getTimestamp(event.getTimeStamp()));
-                
-		if (settings.isRawJsonMessage()) {
-                        gen.writeFieldName("message");
-                        gen.writeRawValue(event.getFormattedMessage());
-                } else {
-                        gen.writeObjectField("message", event.getFormattedMessage());
-                }
-	}
+    @Override
+    protected void serializeCommonFields(JsonGenerator gen, ILoggingEvent event) throws IOException {
+        gen.writeObjectField("@timestamp", getTimestamp(event.getTimeStamp()));
+
+        if (settings.isRawJsonMessage()) {
+            gen.writeFieldName("message");
+            gen.writeRawValue(event.getFormattedMessage());
+        } else {
+            gen.writeObjectField("message", event.getFormattedMessage());
+        }
+
+        if(settings.isIncludeMdc()) {
+            for (Map.Entry<String, String> entry : event.getMDCPropertyMap().entrySet()) {
+                gen.writeObjectField(entry.getKey(), entry.getValue());
+            }
+        }
+    }
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/BasicAuthentication.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/BasicAuthentication.java
@@ -1,13 +1,14 @@
 package com.internetitem.logback.elasticsearch.config;
 
-import javax.xml.bind.DatatypeConverter;
+import com.internetitem.logback.elasticsearch.util.Base64;
+
 import java.net.HttpURLConnection;
 
 public class BasicAuthentication implements Authentication {
     public void addAuth(HttpURLConnection urlConnection, String body) {
         String userInfo = urlConnection.getURL().getUserInfo();
         if (userInfo != null) {
-            String basicAuth = "Basic " + DatatypeConverter.printBase64Binary(userInfo.getBytes());
+            String basicAuth = "Basic " + Base64.encode(userInfo.getBytes());
             urlConnection.setRequestProperty("Authorization", basicAuth);
         }
     }

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/Settings.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/Settings.java
@@ -18,7 +18,8 @@ public class Settings {
 	private boolean logsToStderr;
 	private boolean errorsToStderr;
 	private boolean includeCallerData;
-        private boolean rawJsonMessage;
+	private boolean includeMdc;
+	private boolean rawJsonMessage;
 	private int maxQueueSize = 100 * 1024 * 1024;
 	private Authentication authentication;
 
@@ -143,5 +144,13 @@ public class Settings {
 
 	public void setAuthentication(Authentication authentication) {
 		this.authentication = authentication;
+	}
+
+	public boolean isIncludeMdc() {
+		return includeMdc;
+	}
+
+	public void setIncludeMdc(boolean includeMdc) {
+		this.includeMdc = includeMdc;
 	}
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/util/Base64.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/util/Base64.java
@@ -1,0 +1,103 @@
+package com.internetitem.logback.elasticsearch.util;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * @author Sridharan Kuppa
+ *         created on 12/8/16
+ */
+public class Base64
+{
+    public static String encode(byte[] data)
+    {
+        char[] tbl = {
+            'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P',
+            'Q','R','S','T','U','V','W','X','Y','Z','a','b','c','d','e','f',
+            'g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v',
+            'w','x','y','z','0','1','2','3','4','5','6','7','8','9','+','/' };
+
+        StringBuilder buffer = new StringBuilder();
+        int pad = 0;
+        for (int i = 0; i < data.length; i += 3) {
+
+            int b = ((data[i] & 0xFF) << 16) & 0xFFFFFF;
+            if (i + 1 < data.length) {
+                b |= (data[i+1] & 0xFF) << 8;
+            } else {
+                pad++;
+            }
+            if (i + 2 < data.length) {
+                b |= (data[i+2] & 0xFF);
+            } else {
+                pad++;
+            }
+
+            for (int j = 0; j < 4 - pad; j++) {
+                int c = (b & 0xFC0000) >> 18;
+                buffer.append(tbl[c]);
+                b <<= 6;
+            }
+        }
+        for (int j = 0; j < pad; j++) {
+            buffer.append("=");
+        }
+
+        return buffer.toString();
+    }
+
+    public static byte[] decode(String data)
+    {
+        int[] tbl = {
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63, 52, 53, 54,
+            55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2,
+            3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+            20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1, -1, 26, 27, 28, 29, 30,
+            31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+            48, 49, 50, 51, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
+        byte[] bytes = data.getBytes();
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        for (int i = 0; i < bytes.length; ) {
+            int b = 0;
+            if (tbl[bytes[i]] != -1) {
+                b = (tbl[bytes[i]] & 0xFF) << 18;
+            }
+            // skip unknown characters
+            else {
+                i++;
+                continue;
+            }
+
+            int num = 0;
+            if (i + 1 < bytes.length && tbl[bytes[i+1]] != -1) {
+                b = b | ((tbl[bytes[i+1]] & 0xFF) << 12);
+                num++;
+            }
+            if (i + 2 < bytes.length && tbl[bytes[i+2]] != -1) {
+                b = b | ((tbl[bytes[i+2]] & 0xFF) << 6);
+                num++;
+            }
+            if (i + 3 < bytes.length && tbl[bytes[i+3]] != -1) {
+                b = b | (tbl[bytes[i+3]] & 0xFF);
+                num++;
+            }
+
+            while (num > 0) {
+                int c = (b & 0xFF0000) >> 16;
+                buffer.write((char)c);
+                b <<= 8;
+                num--;
+            }
+            i += 4;
+        }
+        return buffer.toByteArray();
+    }
+}

--- a/src/main/java/com/internetitem/logback/elasticsearch/util/Base64.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/util/Base64.java
@@ -2,10 +2,6 @@ package com.internetitem.logback.elasticsearch.util;
 
 import java.io.ByteArrayOutputStream;
 
-/**
- * @author Sridharan Kuppa
- *         created on 12/8/16
- */
 public class Base64
 {
     public static String encode(byte[] data)

--- a/src/test/java/com/internetitem/logback/elasticsearch/ElasticsearchAppenderTest.java
+++ b/src/test/java/com/internetitem/logback/elasticsearch/ElasticsearchAppenderTest.java
@@ -175,6 +175,7 @@ public class ElasticsearchAppenderTest {
         boolean includeCallerData = false;
         boolean errorsToStderr = false;
         boolean rawJsonMessage = false;
+        boolean includeMdc = true;
         String index = "app-logs";
         String type = "appenderType";
         int maxQueueSize = 10;
@@ -200,6 +201,7 @@ public class ElasticsearchAppenderTest {
         appender.setMaxRetries(maxRetries);
         appender.setConnectTimeout(connectTimeout);
         appender.setRawJsonMessage(rawJsonMessage);
+        appender.setIncludeMdc(includeMdc);
 
         verify(settings, times(1)).setReadTimeout(readTimeout);
         verify(settings, times(1)).setSleepTime(aSleepTime);
@@ -215,6 +217,7 @@ public class ElasticsearchAppenderTest {
         verify(settings, times(1)).setMaxRetries(maxRetries);
         verify(settings, times(1)).setConnectTimeout(connectTimeout);
         verify(settings, times(1)).setRawJsonMessage(rawJsonMessage);
+        verify(settings, times(1)).setIncludeMdc(includeMdc);
     }
 
 


### PR DESCRIPTION
Replace the java.xml.bind (jaxb) package usages with JDK built-in or custom util implementation.
It helps to use this library with with JDK 7 and Android project.