### PR TITLE
Added the ability to copy all MDC entries onto the JSON payload.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ In your `logback.xml`:
             <readTimeout>30000</readTimeout> <!-- optional (in ms, default 30000) -->
             <sleepTime>250</sleepTime> <!-- optional (in ms, default 250) -->
             <rawJsonMessage>false</rawJsonMessage> <!-- optional (default false) -->
+            <includeMdc>false</includeMdc> <!-- optional (default false) -->
             <authentication class="com.internetitem.logback.elasticsearch.config.BasicAuthentication" /> <!-- optional -->
             <properties>
                 <property>
@@ -104,7 +105,8 @@ Configuration Reference
  * `maxQueueSize` (optional, default 104,857,600 = 200MB): Maximum size (in characters) of the send buffer. After this point, *logs will be dropped*. This should only happen if Elasticsearch is down, but this is a self-protection mechanism to ensure that the logging system doesn't cause the main process to run out of memory. Note that this maximum is approximate; once the maximum is hit, no new logs will be accepted until it shrinks, but any logs already accepted to be processed will still be added to the buffer
  * `loggerName` (optional): If set, raw ES-formatted log data will be sent to this logger
  * `errorLoggerName` (optional): If set, any internal errors or problems will be logged to this logger
- * `rawJsonMessage` (optional, default false): If set to `true`, the log message is interpreted as pre-formatted raw JSON message. 
+ * `rawJsonMessage` (optional, default false): If set to `true`, the log message is interpreted as pre-formatted raw JSON message.
+ * `includeMdc` (optional, default false): If set to `true`, then all [MDC](http://www.slf4j.org/api/org/slf4j/MDC.html) values will be mapped to properties on the JSON payload.
  * `authentication` (optional): Add the ability to send authentication headers (see below)
 
 The fields `@timestamp` and `message` are always sent and can not currently be configured. Additional fields can be sent by adding `<property>` elements to the `<properties>` set.
@@ -127,4 +129,3 @@ Included is also an Elasticsearch appender for Logback Access. The configuration
 
  * The Appender class name is `com.internetitem.logback.elasticsearch.ElasticsearchAccessAppender`
  * The `value` for each `property` uses the [Logback Access conversion words](http://logback.qos.ch/manual/layouts.html#logback-access).
-

--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchAppender.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchAppender.java
@@ -123,9 +123,13 @@ public abstract class AbstractElasticsearchAppender<T> extends UnsynchronizedApp
 		this.headers = httpRequestHeaders;
 	}
 
-        public void setRawJsonMessage(boolean rawJsonMessage) {
-                settings.setRawJsonMessage(rawJsonMessage);
-        }
+	public void setRawJsonMessage(boolean rawJsonMessage) {
+			settings.setRawJsonMessage(rawJsonMessage);
+	}
+
+	public void setIncludeMdc(boolean includeMdc) {
+		settings.setIncludeMdc(includeMdc);
+	}
 
     public void setAuthentication(Authentication auth) {
         settings.setAuthentication(auth);

--- a/src/main/java/com/internetitem/logback/elasticsearch/ClassicElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/ClassicElasticsearchPublisher.java
@@ -1,6 +1,7 @@
 package com.internetitem.logback.elasticsearch;
 
 import java.io.IOException;
+import java.util.Map;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Context;
@@ -15,24 +16,30 @@ import com.internetitem.logback.elasticsearch.util.ErrorReporter;
 
 public class ClassicElasticsearchPublisher extends AbstractElasticsearchPublisher<ILoggingEvent> {
 
-	public ClassicElasticsearchPublisher(Context context, ErrorReporter errorReporter, Settings settings, ElasticsearchProperties properties, HttpRequestHeaders headers) throws IOException {
-		super(context, errorReporter, settings, properties, headers);
-	}
+    public ClassicElasticsearchPublisher(Context context, ErrorReporter errorReporter, Settings settings, ElasticsearchProperties properties, HttpRequestHeaders headers) throws IOException {
+        super(context, errorReporter, settings, properties, headers);
+    }
 
-	@Override
-	protected AbstractPropertyAndEncoder<ILoggingEvent> buildPropertyAndEncoder(Context context, Property property) {
-		return new ClassicPropertyAndEncoder(property, context);
-	}
+    @Override
+    protected AbstractPropertyAndEncoder<ILoggingEvent> buildPropertyAndEncoder(Context context, Property property) {
+        return new ClassicPropertyAndEncoder(property, context);
+    }
 
-	@Override
-	protected void serializeCommonFields(JsonGenerator gen, ILoggingEvent event) throws IOException {
-		gen.writeObjectField("@timestamp", getTimestamp(event.getTimeStamp()));
-                
-		if (settings.isRawJsonMessage()) {
-                        gen.writeFieldName("message");
-                        gen.writeRawValue(event.getFormattedMessage());
-                } else {
-                        gen.writeObjectField("message", event.getFormattedMessage());
-                }
-	}
+    @Override
+    protected void serializeCommonFields(JsonGenerator gen, ILoggingEvent event) throws IOException {
+        gen.writeObjectField("@timestamp", getTimestamp(event.getTimeStamp()));
+
+        if (settings.isRawJsonMessage()) {
+            gen.writeFieldName("message");
+            gen.writeRawValue(event.getFormattedMessage());
+        } else {
+            gen.writeObjectField("message", event.getFormattedMessage());
+        }
+
+        if(settings.isIncludeMdc()) {
+            for (Map.Entry<String, String> entry : event.getMDCPropertyMap().entrySet()) {
+                gen.writeObjectField(entry.getKey(), entry.getValue());
+            }
+        }
+    }
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/Settings.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/Settings.java
@@ -18,7 +18,8 @@ public class Settings {
 	private boolean logsToStderr;
 	private boolean errorsToStderr;
 	private boolean includeCallerData;
-        private boolean rawJsonMessage;
+	private boolean includeMdc;
+	private boolean rawJsonMessage;
 	private int maxQueueSize = 100 * 1024 * 1024;
 	private Authentication authentication;
 
@@ -143,5 +144,13 @@ public class Settings {
 
 	public void setAuthentication(Authentication authentication) {
 		this.authentication = authentication;
+	}
+
+	public boolean isIncludeMdc() {
+		return includeMdc;
+	}
+
+	public void setIncludeMdc(boolean includeMdc) {
+		this.includeMdc = includeMdc;
 	}
 }

--- a/src/test/java/com/internetitem/logback/elasticsearch/ElasticsearchAppenderTest.java
+++ b/src/test/java/com/internetitem/logback/elasticsearch/ElasticsearchAppenderTest.java
@@ -175,6 +175,7 @@ public class ElasticsearchAppenderTest {
         boolean includeCallerData = false;
         boolean errorsToStderr = false;
         boolean rawJsonMessage = false;
+        boolean includeMdc = true;
         String index = "app-logs";
         String type = "appenderType";
         int maxQueueSize = 10;
@@ -200,6 +201,7 @@ public class ElasticsearchAppenderTest {
         appender.setMaxRetries(maxRetries);
         appender.setConnectTimeout(connectTimeout);
         appender.setRawJsonMessage(rawJsonMessage);
+        appender.setIncludeMdc(includeMdc);
 
         verify(settings, times(1)).setReadTimeout(readTimeout);
         verify(settings, times(1)).setSleepTime(aSleepTime);
@@ -215,6 +217,7 @@ public class ElasticsearchAppenderTest {
         verify(settings, times(1)).setMaxRetries(maxRetries);
         verify(settings, times(1)).setConnectTimeout(connectTimeout);
         verify(settings, times(1)).setRawJsonMessage(rawJsonMessage);
+        verify(settings, times(1)).setIncludeMdc(includeMdc);
     }
 
 


### PR DESCRIPTION
This allows adding context information without having to configure the properties explicitly with the `%X{key}` patterns.

We use the MDC a lot to add context to our log messages, in particular for filtering in Kibana. Having to configure the properties manually has become more than just a bit tedious, particularly since we now started dynamically adding things like the `@PathParam`s from JAX-RS.

The patch adds the ability to dump all MDC entries into elastic properties, no questions asks. It's off by default for backwards-compatibility.

I couldn't quite figure out an easy way to get test coverage on that feature, but I tested it manually against one of our applications.