### PR TITLE
Replace JAXB dependency

### DIFF
--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
@@ -1,13 +1,5 @@
 package com.internetitem.logback.elasticsearch;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.xml.bind.DatatypeConverter;
-
 import ch.qos.logback.core.Context;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -21,11 +13,20 @@ import com.internetitem.logback.elasticsearch.writer.ElasticsearchWriter;
 import com.internetitem.logback.elasticsearch.writer.LoggerWriter;
 import com.internetitem.logback.elasticsearch.writer.StdErrWriter;
 
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
 public abstract class AbstractElasticsearchPublisher<T> implements Runnable {
 
 	private static final AtomicInteger THREAD_COUNTER = new AtomicInteger(1);
+	private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.ssZ");
 
 	public static final String THREAD_NAME_PREFIX = "es-writer-";
+
 
 	private volatile List<T> events;
 	private ElasticsearchOutputAggregator outputAggregator;
@@ -190,9 +191,7 @@ public abstract class AbstractElasticsearchPublisher<T> implements Runnable {
 	protected abstract void serializeCommonFields(JsonGenerator gen, T event) throws IOException;
 
 	protected static String getTimestamp(long timestamp) {
-		Calendar cal = Calendar.getInstance();
-		cal.setTimeInMillis(timestamp);
-		return DatatypeConverter.printDateTime(cal);
+		return DATE_FORMAT.format(new Date(timestamp));
 	}
 
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
@@ -14,6 +14,7 @@ import com.internetitem.logback.elasticsearch.writer.LoggerWriter;
 import com.internetitem.logback.elasticsearch.writer.StdErrWriter;
 
 import java.io.IOException;
+import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -23,7 +24,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 public abstract class AbstractElasticsearchPublisher<T> implements Runnable {
 
 	private static final AtomicInteger THREAD_COUNTER = new AtomicInteger(1);
-	private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.ssZ");
+	private static final ThreadLocal<DateFormat> DATE_FORMAT = new ThreadLocal<DateFormat> () {
+		@Override
+		protected DateFormat initialValue() {
+			return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.ssZ");
+		}
+	};
 
 	public static final String THREAD_NAME_PREFIX = "es-writer-";
 
@@ -191,7 +197,7 @@ public abstract class AbstractElasticsearchPublisher<T> implements Runnable {
 	protected abstract void serializeCommonFields(JsonGenerator gen, T event) throws IOException;
 
 	protected static String getTimestamp(long timestamp) {
-		return DATE_FORMAT.format(new Date(timestamp));
+		return DATE_FORMAT.get().format(new Date(timestamp));
 	}
 
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/BasicAuthentication.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/BasicAuthentication.java
@@ -1,13 +1,14 @@
 package com.internetitem.logback.elasticsearch.config;
 
-import javax.xml.bind.DatatypeConverter;
+import com.internetitem.logback.elasticsearch.util.Base64;
+
 import java.net.HttpURLConnection;
 
 public class BasicAuthentication implements Authentication {
     public void addAuth(HttpURLConnection urlConnection, String body) {
         String userInfo = urlConnection.getURL().getUserInfo();
         if (userInfo != null) {
-            String basicAuth = "Basic " + DatatypeConverter.printBase64Binary(userInfo.getBytes());
+            String basicAuth = "Basic " + Base64.encode(userInfo.getBytes());
             urlConnection.setRequestProperty("Authorization", basicAuth);
         }
     }

--- a/src/main/java/com/internetitem/logback/elasticsearch/util/Base64.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/util/Base64.java
@@ -1,0 +1,103 @@
+package com.internetitem.logback.elasticsearch.util;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * @author Sridharan Kuppa
+ *         created on 12/8/16
+ */
+public class Base64
+{
+    public static String encode(byte[] data)
+    {
+        char[] tbl = {
+            'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P',
+            'Q','R','S','T','U','V','W','X','Y','Z','a','b','c','d','e','f',
+            'g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v',
+            'w','x','y','z','0','1','2','3','4','5','6','7','8','9','+','/' };
+
+        StringBuilder buffer = new StringBuilder();
+        int pad = 0;
+        for (int i = 0; i < data.length; i += 3) {
+
+            int b = ((data[i] & 0xFF) << 16) & 0xFFFFFF;
+            if (i + 1 < data.length) {
+                b |= (data[i+1] & 0xFF) << 8;
+            } else {
+                pad++;
+            }
+            if (i + 2 < data.length) {
+                b |= (data[i+2] & 0xFF);
+            } else {
+                pad++;
+            }
+
+            for (int j = 0; j < 4 - pad; j++) {
+                int c = (b & 0xFC0000) >> 18;
+                buffer.append(tbl[c]);
+                b <<= 6;
+            }
+        }
+        for (int j = 0; j < pad; j++) {
+            buffer.append("=");
+        }
+
+        return buffer.toString();
+    }
+
+    public static byte[] decode(String data)
+    {
+        int[] tbl = {
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63, 52, 53, 54,
+            55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2,
+            3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+            20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1, -1, 26, 27, 28, 29, 30,
+            31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+            48, 49, 50, 51, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
+        byte[] bytes = data.getBytes();
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        for (int i = 0; i < bytes.length; ) {
+            int b = 0;
+            if (tbl[bytes[i]] != -1) {
+                b = (tbl[bytes[i]] & 0xFF) << 18;
+            }
+            // skip unknown characters
+            else {
+                i++;
+                continue;
+            }
+
+            int num = 0;
+            if (i + 1 < bytes.length && tbl[bytes[i+1]] != -1) {
+                b = b | ((tbl[bytes[i+1]] & 0xFF) << 12);
+                num++;
+            }
+            if (i + 2 < bytes.length && tbl[bytes[i+2]] != -1) {
+                b = b | ((tbl[bytes[i+2]] & 0xFF) << 6);
+                num++;
+            }
+            if (i + 3 < bytes.length && tbl[bytes[i+3]] != -1) {
+                b = b | (tbl[bytes[i+3]] & 0xFF);
+                num++;
+            }
+
+            while (num > 0) {
+                int c = (b & 0xFF0000) >> 16;
+                buffer.write((char)c);
+                b <<= 8;
+                num--;
+            }
+            i += 4;
+        }
+        return buffer.toByteArray();
+    }
+}

--- a/src/main/java/com/internetitem/logback/elasticsearch/util/Base64.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/util/Base64.java
@@ -2,10 +2,6 @@ package com.internetitem.logback.elasticsearch.util;
 
 import java.io.ByteArrayOutputStream;
 
-/**
- * @author Sridharan Kuppa
- *         created on 12/8/16
- */
 public class Base64
 {
     public static String encode(byte[] data)


### PR DESCRIPTION
Replace the java.xml.bind (jaxb) package usages with JDK built-in or custom util implementation.
It helps to use this library with with JDK 7 and Android project.

Note: This PR was originally raised by @skuppa as #24