### PR TITLE
Setting optional max message size. 

### DIFF
--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchAppender.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchAppender.java
@@ -134,4 +134,8 @@ public abstract class AbstractElasticsearchAppender<T> extends UnsynchronizedApp
     public void setAuthentication(Authentication auth) {
         settings.setAuthentication(auth);
     }
+
+    public void setMaxMessgaeSize(int maxMessageSize) {
+    	settings.setMaxMessageSize(maxMessageSize);
+	}
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/ClassicElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/ClassicElasticsearchPublisher.java
@@ -33,7 +33,11 @@ public class ClassicElasticsearchPublisher extends AbstractElasticsearchPublishe
             gen.writeFieldName("message");
             gen.writeRawValue(event.getFormattedMessage());
         } else {
-            gen.writeObjectField("message", event.getFormattedMessage());
+            String formattedMessage = event.getFormattedMessage();
+            if (settings.getMaxMessageSize() > 0 && formattedMessage.length() > settings.getMaxMessageSize()) {
+                formattedMessage = formattedMessage.substring(0, settings.getMaxMessageSize()) + "..";
+            }
+            gen.writeObjectField("message", formattedMessage);
         }
 
         if(settings.isIncludeMdc()) {

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/Settings.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/Settings.java
@@ -22,6 +22,7 @@ public class Settings {
 	private boolean rawJsonMessage;
 	private int maxQueueSize = 100 * 1024 * 1024;
 	private Authentication authentication;
+	private int maxMessageSize = -1;
 
 	public String getIndex() {
 		return index;
@@ -130,7 +131,7 @@ public class Settings {
 		this.errorLoggerName = errorLoggerName;
 	}
         
-        public boolean isRawJsonMessage() {
+	public boolean isRawJsonMessage() {
 		return rawJsonMessage;
 	}
 
@@ -152,5 +153,13 @@ public class Settings {
 
 	public void setIncludeMdc(boolean includeMdc) {
 		this.includeMdc = includeMdc;
+	}
+
+	public int getMaxMessageSize() {
+		return maxMessageSize;
+	}
+
+	public void setMaxMessageSize(int maxMessageSize) {
+		this.maxMessageSize = maxMessageSize;
 	}
 }


### PR DESCRIPTION
Setting optional max message size. When message size is too big and it might run into out of memory error also it is not advisable to index a big message as logging event.  By default there is no message size limit.