### PR TITLE
Use DefaultAwsRegionProviderChain

### DIFF
--- a/src/main/java/com/internetitem/logback/elasticsearch/config/AWSAuthentication.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/AWSAuthentication.java
@@ -18,7 +18,7 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.http.HttpMethodName;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.regions.DefaultAwsRegionProviderChain;
 import com.amazonaws.util.StringInputStream;
 
 /**

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/AWSAuthentication.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/AWSAuthentication.java
@@ -18,7 +18,7 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.http.HttpMethodName;
-import com.amazonaws.regions.AwsRegionProviderChain;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.util.StringInputStream;
 
 /**
@@ -34,7 +34,7 @@ public class AWSAuthentication implements Authentication {
     public AWSAuthentication() {
         signer = new AWS4Signer(false);
         signer.setServiceName("es");
-        signer.setRegionName(new AwsRegionProviderChain().getRegion());
+        signer.setRegionName(new DefaultAwsRegionProviderChain().getRegion());
         AWSCredentialsProvider credsProvider = new DefaultAWSCredentialsProviderChain();
         credentials = credsProvider.getCredentials();
     }


### PR DESCRIPTION
AWSRegionProviderChain requires you pass in providers. In the present state this will always fail to obtain region as it was being newed up without any providers.

The DefaultAwsRegionProviderChain will find the providers to pick up the region

Thanks

Wrisk Team