### PR TITLE
support multi elastic nodes

### DIFF
--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchAppender.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchAppender.java
@@ -108,7 +108,7 @@ public abstract class AbstractElasticsearchAppender<T> extends UnsynchronizedApp
 	}
 
 	public void setUrl(String url) throws MalformedURLException {
-		settings.setUrl(new URL(url));
+		settings.setUrl(url);
 	}
 
 	public void setLoggerName(String logger) {

--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
@@ -119,7 +119,10 @@ public abstract class AbstractElasticsearchPublisher<T> implements Runnable {
 		int maxRetries = settings.getMaxRetries();
 		while (true) {
 			try {
-				Thread.sleep(settings.getSleepTime());
+
+				if (!outputAggregator.canSendData()) {
+					Thread.sleep(settings.getSleepTime());
+				}
 
 				List<T> eventsCopy = null;
 				synchronized (lock) {

--- a/src/main/java/com/internetitem/logback/elasticsearch/ElasticsearchOutputAggregator.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/ElasticsearchOutputAggregator.java
@@ -63,6 +63,15 @@ public class ElasticsearchOutputAggregator extends Writer {
 		return success;
 	}
 
+	public boolean canSendData() {
+		for (SafeWriter writer : writers) {
+			if (writer.canSendData()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	@Override
 	public void flush() throws IOException {
 		// No-op

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/Settings.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/Settings.java
@@ -1,12 +1,10 @@
 package com.internetitem.logback.elasticsearch.config;
 
-import java.net.URL;
-
 public class Settings {
 
 	private String index;
 	private String type;
-	private URL url;
+	private String url;
 
 	private String loggerName;
 	private String errorLoggerName;
@@ -115,11 +113,11 @@ public class Settings {
 		this.loggerName = loggerName;
 	}
 
-	public URL getUrl() {
+	public String getUrl() {
 		return url;
 	}
 
-	public void setUrl(URL url) {
+	public void setUrl(String url) {
 		this.url = url;
 	}
 

--- a/src/main/java/com/internetitem/logback/elasticsearch/writer/ElasticsearchWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/writer/ElasticsearchWriter.java
@@ -97,9 +97,9 @@ public class ElasticsearchWriter implements SafeWriter {
 			}
 		} finally {
 			urlConnection.disconnect();
+			sendBuffer.setLength(0);		// clear buffer when send failed
 		}
 
-		sendBuffer.setLength(0);
 		if (bufferExceeded) {
 			errorReporter.logInfo("Send queue cleared - log messages will no longer be lost");
 			bufferExceeded = false;

--- a/src/main/java/com/internetitem/logback/elasticsearch/writer/ElasticsearchWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/writer/ElasticsearchWriter.java
@@ -61,7 +61,7 @@ public class ElasticsearchWriter implements SafeWriter {
 		}
 
 		String body = sendBuffer.toString();
-		sendBuffer.setLength(0);
+		sendBuffer.setLength(0);			// 	acceptable data loss
 		HttpURLConnection urlConnection = (HttpURLConnection)(new URL(urls[current]).openConnection());
 
 		try {

--- a/src/main/java/com/internetitem/logback/elasticsearch/writer/LoggerWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/writer/LoggerWriter.java
@@ -27,4 +27,9 @@ public class LoggerWriter implements SafeWriter {
 	public boolean hasPendingData() {
 		return false;
 	}
+
+	@Override
+	public boolean canSendData() {
+		return false;
+	}
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/writer/SafeWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/writer/SafeWriter.java
@@ -9,4 +9,6 @@ public interface SafeWriter {
 	void sendData() throws IOException;
 
 	boolean hasPendingData();
+
+	boolean canSendData();
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/writer/StdErrWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/writer/StdErrWriter.java
@@ -13,4 +13,9 @@ public class StdErrWriter implements SafeWriter {
 	public boolean hasPendingData() {
 		return false;
 	}
+
+	@Override
+	public boolean canSendData() {
+		return false;
+	}
 }

--- a/src/test/java/com/internetitem/logback/elasticsearch/ElasticsearchAppenderTest.java
+++ b/src/test/java/com/internetitem/logback/elasticsearch/ElasticsearchAppenderTest.java
@@ -211,7 +211,7 @@ public class ElasticsearchAppenderTest {
         verify(settings, times(1)).setMaxQueueSize(maxQueueSize);
         verify(settings, times(1)).setIndex(index);
         verify(settings, times(1)).setType(type);
-        verify(settings, times(1)).setUrl(new URL(url));
+        verify(settings, times(1)).setUrl(url);
         verify(settings, times(1)).setLoggerName(logger);
         verify(settings, times(1)).setErrorLoggerName(errorLogger);
         verify(settings, times(1)).setMaxRetries(maxRetries);


### PR DESCRIPTION
In my product case, too much log data send to single elasticsearch mast node. this cause heavy load of network traffic. So I change some code to send to multi mast nodes. Split node url by comma in logger.xml like this:

`<url>http://yourserver_1/_bulk,http://yourserver_2/_bulk,http://yourserver_3:9200/_bulk</url>`