### PR TITLE
New setting maxEvents to limit number of log events added for later processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Configuration Reference
  * `errorsToStderr` (optional, default false): If set to `true`, any errors in communicating with Elasticsearch will also be dumped to stderr (normally they are only reported to the internal Logback Status system, in order to prevent a feedback loop)
  * `logsToStderr` (optional, default false): If set to `true`, dump the raw Elasticsearch messages to stderr
  * `maxQueueSize` (optional, default 104,857,600 = 200MB): Maximum size (in characters) of the send buffer. After this point, *logs will be dropped*. This should only happen if Elasticsearch is down, but this is a self-protection mechanism to ensure that the logging system doesn't cause the main process to run out of memory. Note that this maximum is approximate; once the maximum is hit, no new logs will be accepted until it shrinks, but any logs already accepted to be processed will still be added to the buffer
- * `maxEvents` (optional, default -1 i.e. not limited): Maximum about of logging events to be stored for later sending. 
+ * `maxEvents` (optional, default -1 i.e. not limited): Maximum amount of logging events to be stored for later sending. 
  * `loggerName` (optional): If set, raw ES-formatted log data will be sent to this logger
  * `errorLoggerName` (optional): If set, any internal errors or problems will be logged to this logger
  * `rawJsonMessage` (optional, default false): If set to `true`, the log message is interpreted as pre-formatted raw JSON message.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ In your `logback.xml`:
             <logsToStderr>false</logsToStderr> <!-- optional (default false) -->
             <maxQueueSize>104857600</maxQueueSize> <!-- optional (default 104857600) -->
             <maxRetries>3</maxRetries> <!-- optional (default 3) -->
+            <maxEvents>100</maxEvents><!-- optional (default -1) -->
             <readTimeout>30000</readTimeout> <!-- optional (in ms, default 30000) -->
             <sleepTime>250</sleepTime> <!-- optional (in ms, default 250) -->
             <rawJsonMessage>false</rawJsonMessage> <!-- optional (default false) -->
@@ -104,6 +105,7 @@ Configuration Reference
  * `errorsToStderr` (optional, default false): If set to `true`, any errors in communicating with Elasticsearch will also be dumped to stderr (normally they are only reported to the internal Logback Status system, in order to prevent a feedback loop)
  * `logsToStderr` (optional, default false): If set to `true`, dump the raw Elasticsearch messages to stderr
  * `maxQueueSize` (optional, default 104,857,600 = 200MB): Maximum size (in characters) of the send buffer. After this point, *logs will be dropped*. This should only happen if Elasticsearch is down, but this is a self-protection mechanism to ensure that the logging system doesn't cause the main process to run out of memory. Note that this maximum is approximate; once the maximum is hit, no new logs will be accepted until it shrinks, but any logs already accepted to be processed will still be added to the buffer
+ * `maxEvents` (optional, default -1 i.e. not limited): Maximum about of logging events to be stored for later sending. 
  * `loggerName` (optional): If set, raw ES-formatted log data will be sent to this logger
  * `errorLoggerName` (optional): If set, any internal errors or problems will be logged to this logger
  * `rawJsonMessage` (optional, default false): If set to `true`, the log message is interpreted as pre-formatted raw JSON message.

--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchAppender.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchAppender.java
@@ -138,4 +138,8 @@ public abstract class AbstractElasticsearchAppender<T> extends UnsynchronizedApp
     public void setMaxMessageSize(int maxMessageSize) {
     	settings.setMaxMessageSize(maxMessageSize);
 	}
+    
+    public void setMaxEvents(int maxEvents) {
+    	settings.setMaxEvents(maxEvents);
+    }
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
@@ -104,8 +104,12 @@ public abstract class AbstractElasticsearchPublisher<T> implements Runnable {
 			return;
 		}
 
+		int max = settings.getMaxEvents();
 		synchronized (lock) {
 			events.add(event);
+			if (max > 0 && events.size() > max) {
+				events.subList(0, events.size() - max).clear();
+			}
 			if (!working) {
 				working = true;
 				Thread thread = new Thread(this, THREAD_NAME_PREFIX + THREAD_COUNTER.getAndIncrement());

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/Settings.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/Settings.java
@@ -23,6 +23,7 @@ public class Settings {
 	private int maxQueueSize = 100 * 1024 * 1024;
 	private Authentication authentication;
 	private int maxMessageSize = -1;
+	private int maxEvents = -1;
 
 	public String getIndex() {
 		return index;
@@ -161,5 +162,13 @@ public class Settings {
 
 	public void setMaxMessageSize(int maxMessageSize) {
 		this.maxMessageSize = maxMessageSize;
+	}
+
+	public int getMaxEvents() {
+		return maxEvents;
+	}
+
+	public void setMaxEvents(int maxEvents) {
+		this.maxEvents = maxEvents;
 	}
 }


### PR DESCRIPTION
Limits memory affected by issue #44 