### PR TITLE
"object" data type for properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ In your `logback.xml`:
             <appender name="ES_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
                 <!-- ... -->
                 <encoder>
-                    <pattern>%msg</pattern> <!-- This pattern is important, otherwise it won't be the raw Elasticsearch format anyomre -->
+                    <pattern>%msg</pattern> <!-- This pattern is important, otherwise it won't be the raw Elasticsearch format anymore -->
                 </encoder>
             </appender>
         </logger>
@@ -116,7 +116,7 @@ The fields `@timestamp` and `message` are always sent and can not currently be c
  * `name` (required): Key to be used in the log event
  * `value` (required): Text string to be sent. Internally, the value is populated using a Logback PatternLayout, so all [Conversion Words](http://logback.qos.ch/manual/layouts.html#conversionWord) can be used (in addition to the standard static variable interpolations like `${HOSTNAME}`).
  * `allowEmpty` (optional, default `false`): Normally, if the `value` results in a `null` or empty string, the field will not be sent. If `allowEmpty` is set to `true` then the field will be sent regardless
- * `type` (optional, default `String`): type of the field on the resulting JSON message. Possible values are: `String`, `int`, `float` and `boolean`.
+ * `type` (optional, default `String`): type of the field on the resulting JSON message. Possible values are: `String`, `int`, `float`, `boolean` and `object`. Use `object` if the value is the string representation of a JSON object or array ie. `{"k" : true}`or `[1,2,3,]`.
 
 Groovy Configuration
 ====================

--- a/src/main/java/com/internetitem/logback/elasticsearch/PropertySerializer.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/PropertySerializer.java
@@ -19,6 +19,9 @@ class PropertySerializer<T> {
                 case BOOLEAN:
                     serializeBooleanField(jsonGenerator, propertyAndEncoder, value);
                     break;
+                case OBJECT:
+                    serializeJsonObjectField(jsonGenerator, propertyAndEncoder, value);
+                    break;
                 default:
                     serializeStringField(jsonGenerator, propertyAndEncoder, value);
             }
@@ -48,6 +51,21 @@ class PropertySerializer<T> {
     private void serializeBooleanField(JsonGenerator jsonGenerator, AbstractPropertyAndEncoder<T> propertyAndEncoder, String value) throws IOException {
         if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("false")) {
             jsonGenerator.writeBooleanField(propertyAndEncoder.getName(), Boolean.valueOf(value));
+        } else {
+            serializeStringField(jsonGenerator, propertyAndEncoder, value);
+        }
+    }
+
+
+    private void serializeJsonObjectField(JsonGenerator jsonGenerator, AbstractPropertyAndEncoder<T> propertyAndEncoder, String value) throws IOException {
+        String trimmed = value != null ? value.trim() : "";
+        if ("".equals(value)) {
+            jsonGenerator.writeFieldName(propertyAndEncoder.getName());
+            jsonGenerator.writeRawValue("{}");
+        } else if ((trimmed.startsWith("{") && trimmed.endsWith("}"))
+                || (trimmed.startsWith("[") && trimmed.endsWith("]"))) {
+            jsonGenerator.writeFieldName(propertyAndEncoder.getName());
+            jsonGenerator.writeRawValue(trimmed);
         } else {
             serializeStringField(jsonGenerator, propertyAndEncoder, value);
         }

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/Property.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/Property.java
@@ -7,7 +7,7 @@ public class Property {
 	private Type type = Type.STRING;
 
 	public enum Type {
-		STRING, INT, FLOAT, BOOLEAN
+		STRING, INT, FLOAT, BOOLEAN, OBJECT
 	}
 
 	public Property() {

--- a/src/test/java/com/internetitem/logback/elasticsearch/PropertySerializerTest.java
+++ b/src/test/java/com/internetitem/logback/elasticsearch/PropertySerializerTest.java
@@ -138,4 +138,49 @@ public class PropertySerializerTest {
         // then
         verify(jsonGenerator).writeObject("value");
     }
+
+    @Test
+    public void should_serialize_object_as_raw_json()  throws Exception {
+        Property property = new Property();
+        property.setName("args");
+        property.setValue("{\"name\": \"value\", \"serial\": 1} ");
+        property.setType("object");
+
+        org.mockito.Mockito.reset(jsonGenerator);
+        // when
+        propertySerializer.serializeProperty(jsonGenerator, loggingEvent, new ClassicPropertyAndEncoder(property, context));
+
+        // then
+        verify(jsonGenerator).writeRawValue("{\"name\": \"value\", \"serial\": 1}");
+    }
+
+    @Test
+    public void should_serialize_empty_object()  throws Exception {
+        Property property = new Property();
+        property.setName("args");
+        property.setValue("");
+        property.setType("object");
+        property.setAllowEmpty(true);
+
+        // when
+        propertySerializer.serializeProperty(jsonGenerator, loggingEvent, new ClassicPropertyAndEncoder(property, context));
+
+        // then
+        verify(jsonGenerator).writeRawValue("{}");
+    }
+
+    @Test
+    public void should_serialize_invalid_object_as_text()  throws Exception {
+        Property property = new Property();
+        property.setName("args2");
+        property.setValue("{\"name\": \"value\"");
+        property.setType("object");
+
+        org.mockito.Mockito.reset(jsonGenerator);
+        // when
+        propertySerializer.serializeProperty(jsonGenerator, loggingEvent, new ClassicPropertyAndEncoder(property, context));
+
+        // then
+        verify(jsonGenerator).writeObject("{\"name\": \"value\"");
+    }
 }


### PR DESCRIPTION
useful when the property contains JSON data, for example a serialized object like a Map; it saves you the trouble create a pipeline with a JSON processor in Elastic

example:
```
<property>
 <name>params</name>
 <value>%mdc{httpParameters}</value>
 <type>object</type>
 <allowEmpty>false</allowEmpty>
</property>
```
with the following in a Filter or Servlet
`MDC.put("httpParameters", new GsonBuilder().create().toJson(request.getParameterMap()));`