### PR TITLE
setting to exclude MDC keys from being sent to Elastic

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ In your `logback.xml`:
             <sleepTime>250</sleepTime> <!-- optional (in ms, default 250) -->
             <rawJsonMessage>false</rawJsonMessage> <!-- optional (default false) -->
             <includeMdc>false</includeMdc> <!-- optional (default false) -->
+            <excludedMdcKeys>stacktrace</excludedMdcKeys> <!-- optional (default empty) -->
             <maxMessageSize>100</maxMessageSize> <!-- optional (default -1 -->
             <authentication class="com.internetitem.logback.elasticsearch.config.BasicAuthentication" /> <!-- optional -->
             <properties>
@@ -108,6 +109,7 @@ Configuration Reference
  * `errorLoggerName` (optional): If set, any internal errors or problems will be logged to this logger
  * `rawJsonMessage` (optional, default false): If set to `true`, the log message is interpreted as pre-formatted raw JSON message.
  * `includeMdc` (optional, default false): If set to `true`, then all [MDC](http://www.slf4j.org/api/org/slf4j/MDC.html) values will be mapped to properties on the JSON payload.
+ * `excludedMdcKeys` (optional, default empty): comma separated (extra whitespace is fine) list of case sensitive MDC keys that should not be mapped automatically to properties; only useful when includeMdc is set to `true`
  * `maxMessageSize` (optional, default -1): If set to a number greater than 0, truncate messages larger than this length, then append "`..`" to denote that the message was truncated
  * `authentication` (optional): Add the ability to send authentication headers (see below)
 

--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchAppender.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchAppender.java
@@ -1,15 +1,12 @@
 package com.internetitem.logback.elasticsearch;
 
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import com.internetitem.logback.elasticsearch.config.*;
+import com.internetitem.logback.elasticsearch.util.ErrorReporter;
+
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-
-import ch.qos.logback.core.UnsynchronizedAppenderBase;
-import com.internetitem.logback.elasticsearch.config.Authentication;
-import com.internetitem.logback.elasticsearch.config.ElasticsearchProperties;
-import com.internetitem.logback.elasticsearch.config.HttpRequestHeaders;
-import com.internetitem.logback.elasticsearch.config.Settings;
-import com.internetitem.logback.elasticsearch.util.ErrorReporter;
 
 public abstract class AbstractElasticsearchAppender<T> extends UnsynchronizedAppenderBase<T> {
 
@@ -129,6 +126,10 @@ public abstract class AbstractElasticsearchAppender<T> extends UnsynchronizedApp
 
 	public void setIncludeMdc(boolean includeMdc) {
 		settings.setIncludeMdc(includeMdc);
+	}
+
+	public void setExcludedMdcKeys(String setExcludedMdcKeys) {
+		settings.setExcludedMdcKeys(setExcludedMdcKeys);
 	}
 
     public void setAuthentication(Authentication auth) {

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/Settings.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/Settings.java
@@ -19,6 +19,7 @@ public class Settings {
 	private boolean errorsToStderr;
 	private boolean includeCallerData;
 	private boolean includeMdc;
+	private String excludedMdcKeys;
 	private boolean rawJsonMessage;
 	private int maxQueueSize = 100 * 1024 * 1024;
 	private Authentication authentication;
@@ -153,6 +154,14 @@ public class Settings {
 
 	public void setIncludeMdc(boolean includeMdc) {
 		this.includeMdc = includeMdc;
+	}
+
+	public String getExcludedMdcKeys() {
+		return excludedMdcKeys;
+	}
+
+	public void setExcludedMdcKeys(String excludedMdcKeys) {
+		this.excludedMdcKeys = excludedMdcKeys;
 	}
 
 	public int getMaxMessageSize() {

--- a/src/test/java/com/internetitem/logback/elasticsearch/ElasticsearchAppenderTest.java
+++ b/src/test/java/com/internetitem/logback/elasticsearch/ElasticsearchAppenderTest.java
@@ -176,6 +176,7 @@ public class ElasticsearchAppenderTest {
         boolean errorsToStderr = false;
         boolean rawJsonMessage = false;
         boolean includeMdc = true;
+        String excludedMdcKeys = "stacktrace,url";
         String index = "app-logs";
         String type = "appenderType";
         int maxQueueSize = 10;
@@ -202,6 +203,7 @@ public class ElasticsearchAppenderTest {
         appender.setConnectTimeout(connectTimeout);
         appender.setRawJsonMessage(rawJsonMessage);
         appender.setIncludeMdc(includeMdc);
+        appender.setExcludedMdcKeys(excludedMdcKeys);
 
         verify(settings, times(1)).setReadTimeout(readTimeout);
         verify(settings, times(1)).setSleepTime(aSleepTime);
@@ -218,6 +220,7 @@ public class ElasticsearchAppenderTest {
         verify(settings, times(1)).setConnectTimeout(connectTimeout);
         verify(settings, times(1)).setRawJsonMessage(rawJsonMessage);
         verify(settings, times(1)).setIncludeMdc(includeMdc);
+        verify(settings, times(1)).setExcludedMdcKeys(excludedMdcKeys);
     }
 
 


### PR DESCRIPTION
useful when a particular key (or keys) may contain a lot of text that is of no particular use in your Elastic index, or when you want to explicitly add the key as an object property (see PR #56 for that)

keys are matched case sensitive, without wildcard support