### PR TITLE
Change content-type to application/json

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ In your `logback.xml`:
             <headers>
                 <header>
                     <name>Content-Type</name>
-                    <value>text/plain</value>
+                    <value>application/json</value>
                 </header>
             </headers>
         </appender>


### PR DESCRIPTION
Newer versions of Elasticsearch need the correct content type, in this case `application/json`. See https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests .