### PR TITLE
Context map feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ In your `logback.xml`:
             <includeMdc>false</includeMdc> <!-- optional (default false) -->
             <maxMessageSize>100</maxMessageSize> <!-- optional (default -1 -->
             <authentication class="com.internetitem.logback.elasticsearch.config.BasicAuthentication" /> <!-- optional -->
+            <enableContextMap>false</enableContextMap><!-- optional (default false) -->
             <properties>
                 <property>
                     <name>host</name>
@@ -110,7 +111,7 @@ Configuration Reference
  * `includeMdc` (optional, default false): If set to `true`, then all [MDC](http://www.slf4j.org/api/org/slf4j/MDC.html) values will be mapped to properties on the JSON payload.
  * `maxMessageSize` (optional, default -1): If set to a number greater than 0, truncate messages larger than this length, then append "`..`" to denote that the message was truncated
  * `authentication` (optional): Add the ability to send authentication headers (see below)
-
+ * `enableContextMap` (optional): If the latest parameter in logger call is of type java.util.Map then all content of it will be traversed and written to `message` with prefix `context.*`
 The fields `@timestamp` and `message` are always sent and can not currently be configured. Additional fields can be sent by adding `<property>` elements to the `<properties>` set.
 
  * `name` (required): Key to be used in the log event

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ Configuration Reference
  * `includeMdc` (optional, default false): If set to `true`, then all [MDC](http://www.slf4j.org/api/org/slf4j/MDC.html) values will be mapped to properties on the JSON payload.
  * `maxMessageSize` (optional, default -1): If set to a number greater than 0, truncate messages larger than this length, then append "`..`" to denote that the message was truncated
  * `authentication` (optional): Add the ability to send authentication headers (see below)
- * `enableContextMap` (optional): If the latest parameter in logger call is of type java.util.Map then all content of it will be traversed and written to `message` with prefix `context.*`
+ * `enableContextMap` (optional): If the latest parameter in logger call is of type java.util.Map then all content of it will be traversed and written with prefix `context.*`. For event-specific custom fields.
+
 The fields `@timestamp` and `message` are always sent and can not currently be configured. Additional fields can be sent by adding `<property>` elements to the `<properties>` set.
 
  * `name` (required): Key to be used in the log event

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Configuration Reference
  * `includeMdc` (optional, default false): If set to `true`, then all [MDC](http://www.slf4j.org/api/org/slf4j/MDC.html) values will be mapped to properties on the JSON payload.
  * `maxMessageSize` (optional, default -1): If set to a number greater than 0, truncate messages larger than this length, then append "`..`" to denote that the message was truncated
  * `authentication` (optional): Add the ability to send authentication headers (see below)
- * `enableContextMap` (optional): If the latest parameter in logger call is of type java.util.Map then all content of it will be traversed and written with prefix `context.*`. For event-specific custom fields.
+ * `enableContextMap` (optional): If the latest parameter in logger call is of type java.util.Map then all content of it will be traversed and written with prefix `context.*`. For event-specific custom fields. 
 
 The fields `@timestamp` and `message` are always sent and can not currently be configured. Additional fields can be sent by adding `<property>` elements to the `<properties>` set.
 
@@ -156,3 +156,17 @@ Included is also an Elasticsearch appender for Logback Access. The configuration
 
  * The Appender class name is `com.internetitem.logback.elasticsearch.ElasticsearchAccessAppender`
  * The `value` for each `property` uses the [Logback Access conversion words](http://logback.qos.ch/manual/layouts.html#logback-access).
+
+Event-specific custom fields
+============================
+Log line:
+
+     log.info("Service started in {} seconds", duration/1000, Collections.singletonMap("duration", duration));
+
+Result:
+
+    {
+      "@timestamp": "2014-06-04T15:26:14.464+02:00",
+      "message": "Service started in 12 seconds",
+      "duration": 12368,
+    }

--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchAppender.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchAppender.java
@@ -138,4 +138,8 @@ public abstract class AbstractElasticsearchAppender<T> extends UnsynchronizedApp
     public void setMaxMessageSize(int maxMessageSize) {
     	settings.setMaxMessageSize(maxMessageSize);
 	}
+
+    public void setEnableContextMap(boolean enableContextMap) {
+        settings.setEnableContextMap(enableContextMap);
+    }
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/ClassicElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/ClassicElasticsearchPublisher.java
@@ -12,13 +12,17 @@ import com.internetitem.logback.elasticsearch.config.Property;
 import com.internetitem.logback.elasticsearch.config.Settings;
 import com.internetitem.logback.elasticsearch.util.AbstractPropertyAndEncoder;
 import com.internetitem.logback.elasticsearch.util.ClassicPropertyAndEncoder;
+import com.internetitem.logback.elasticsearch.util.ContextMapWriter;
 import com.internetitem.logback.elasticsearch.util.ErrorReporter;
 
 public class ClassicElasticsearchPublisher extends AbstractElasticsearchPublisher<ILoggingEvent> {
 
     public ClassicElasticsearchPublisher(Context context, ErrorReporter errorReporter, Settings settings, ElasticsearchProperties properties, HttpRequestHeaders headers) throws IOException {
         super(context, errorReporter, settings, properties, headers);
+        contextMapWriter = new ContextMapWriter();
     }
+
+    protected ContextMapWriter contextMapWriter;
 
     @Override
     protected AbstractPropertyAndEncoder<ILoggingEvent> buildPropertyAndEncoder(Context context, Property property) {
@@ -40,10 +44,15 @@ public class ClassicElasticsearchPublisher extends AbstractElasticsearchPublishe
             gen.writeObjectField("message", formattedMessage);
         }
 
-        if(settings.isIncludeMdc()) {
+        if (settings.isIncludeMdc()) {
             for (Map.Entry<String, String> entry : event.getMDCPropertyMap().entrySet()) {
                 gen.writeObjectField(entry.getKey(), entry.getValue());
             }
         }
+
+        if (settings.isEnableContextMap()) {
+            contextMapWriter.writeContextMap(gen, event);
+        }
     }
+
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/Settings.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/Settings.java
@@ -23,6 +23,7 @@ public class Settings {
 	private int maxQueueSize = 100 * 1024 * 1024;
 	private Authentication authentication;
 	private int maxMessageSize = -1;
+    private boolean enableContextMap;
 
 	public String getIndex() {
 		return index;
@@ -130,7 +131,7 @@ public class Settings {
 	public void setErrorLoggerName(String errorLoggerName) {
 		this.errorLoggerName = errorLoggerName;
 	}
-        
+
 	public boolean isRawJsonMessage() {
 		return rawJsonMessage;
 	}
@@ -162,4 +163,12 @@ public class Settings {
 	public void setMaxMessageSize(int maxMessageSize) {
 		this.maxMessageSize = maxMessageSize;
 	}
+
+    public boolean isEnableContextMap() {
+        return enableContextMap;
+    }
+
+    public void setEnableContextMap(boolean enableContextMap) {
+        this.enableContextMap = enableContextMap;
+    }
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/util/ContextMapWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/util/ContextMapWriter.java
@@ -1,0 +1,62 @@
+package com.internetitem.logback.elasticsearch.util;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.fasterxml.jackson.core.JsonGenerator;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+
+public class ContextMapWriter {
+
+    public void writeContextMap(JsonGenerator gen, ILoggingEvent event) throws IOException {
+        Object[] arguments = event.getArgumentArray();
+        if (arguments == null || arguments.length == 0) return;
+        Object lastElement = arguments[arguments.length - 1];
+        if (lastElement instanceof Map) {
+            Map<String, Object> indexes = traverseObject(new HashMap<String, Object>(), "context", lastElement);
+            for (Map.Entry<String, Object> entry : indexes.entrySet()) {
+                String key = entry.getKey();
+                Object value = entry.getValue();
+                gen.writeObjectField(key, value);
+            }
+        }
+    }
+
+    static Map<String, Object> traverseObject(Map<String, Object> accumulator, String context, Object object) {
+        if (object == null) {
+            return accumulator;
+        }
+        if (object instanceof Map) {
+            traverseMap(accumulator, context, (Map) object);
+        } else if (object instanceof Collection) {
+            traverseCollection(accumulator, context, (Collection) object);
+        } else if (object instanceof Number) {
+            accumulator.put(context, object);
+        } else {
+            accumulator.put(context, Objects.toString(object));
+        }
+        return accumulator;
+    }
+
+    static Map<String, Object> traverseCollection(Map<String, Object> accumulator, String context, Collection object) {
+        Iterator iterator = object.iterator();
+        int i = 0;
+        while (iterator.hasNext()) {
+            Object v = iterator.next();
+            traverseObject(accumulator, context + "." + i, v);
+            i++;
+        }
+        return accumulator;
+    }
+
+    static Map<String, Object> traverseMap(Map<String, Object> accumulator, String context, Map<Object, Object> object) {
+        for (Map.Entry entry : object.entrySet()) {
+            traverseObject(accumulator, context + "." + entry.getKey(), entry.getValue());
+        }
+        return accumulator;
+    }
+}

--- a/src/test/java/com/internetitem/logback/elasticsearch/ContextMapWriterTest.java
+++ b/src/test/java/com/internetitem/logback/elasticsearch/ContextMapWriterTest.java
@@ -1,0 +1,46 @@
+package com.internetitem.logback.elasticsearch;
+
+import ch.qos.logback.classic.spi.LoggingEvent;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.internetitem.logback.elasticsearch.util.ContextMapWriter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ContextMapWriterTest {
+
+    @Mock
+    private JsonGenerator jsonGenerator;
+
+
+    private ContextMapWriter contextMapWriter;
+
+    @Before
+    public void setup() throws IOException {
+        contextMapWriter = new ContextMapWriter();
+    }
+
+    @Test
+    public void should_not_write_if_arguments_null_or_empty() throws IOException {
+        LoggingEvent event = new LoggingEvent();
+        contextMapWriter.writeContextMap(jsonGenerator, event);
+        event.setArgumentArray(new Object[]{});
+        contextMapWriter.writeContextMap(jsonGenerator, event);
+        verifyZeroInteractions(jsonGenerator);
+    }
+
+    @Test
+    public void should_not_write_if_last_element_not_map() throws IOException {
+        LoggingEvent event = new LoggingEvent();
+        event.setArgumentArray(new Object[]{"23", 3243});
+        contextMapWriter.writeContextMap(jsonGenerator, event);
+        verifyZeroInteractions(jsonGenerator);
+    }
+}

--- a/src/test/java/com/internetitem/logback/elasticsearch/ElasticsearchAppenderTest.java
+++ b/src/test/java/com/internetitem/logback/elasticsearch/ElasticsearchAppenderTest.java
@@ -186,6 +186,7 @@ public class ElasticsearchAppenderTest {
         int aSleepTime = 10000;
         int readTimeout = 10000;
         int connectTimeout = 5000;
+        boolean enableContextMap = true;
 
         appender.setIncludeCallerData(includeCallerData);
         appender.setSleepTime(aSleepTime);
@@ -202,6 +203,7 @@ public class ElasticsearchAppenderTest {
         appender.setConnectTimeout(connectTimeout);
         appender.setRawJsonMessage(rawJsonMessage);
         appender.setIncludeMdc(includeMdc);
+        appender.setEnableContextMap(enableContextMap);
 
         verify(settings, times(1)).setReadTimeout(readTimeout);
         verify(settings, times(1)).setSleepTime(aSleepTime);
@@ -218,6 +220,8 @@ public class ElasticsearchAppenderTest {
         verify(settings, times(1)).setConnectTimeout(connectTimeout);
         verify(settings, times(1)).setRawJsonMessage(rawJsonMessage);
         verify(settings, times(1)).setIncludeMdc(includeMdc);
+        verify(settings, times(1)).setEnableContextMap(enableContextMap);
+
     }
 
 


### PR DESCRIPTION
Inspired by Context Map feature from logstash-logback-encoder for adding event-specific custom fields to message.
Example:
Log line:
  log.info("Service started in {} seconds", duration/1000, Collections.singletonMap("duration", duration));

Result:
    {
      "@timestamp": "2014-06-04T15:26:14.464+02:00",
      "message": "Service started in 12 seconds",
      "duration": 12368,
    }