### PR TITLE
Fix region retrieving in AWSAuthentication

### DIFF
--- a/src/main/java/com/internetitem/logback/elasticsearch/config/AWSAuthentication.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/AWSAuthentication.java
@@ -18,7 +18,7 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.http.HttpMethodName;
-import com.amazonaws.regions.DefaultAwsRegionProviderChain;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.util.StringInputStream;
 
 /**
@@ -34,7 +34,7 @@ public class AWSAuthentication implements Authentication {
     public AWSAuthentication() {
         signer = new AWS4Signer(false);
         signer.setServiceName("es");
-        signer.setRegionName(new DefaultAwsRegionProviderChain().getRegion());
+        signer.setRegionName(getCurrentRegion());
         AWSCredentialsProvider credsProvider = new DefaultAWSCredentialsProviderChain();
         credentials = credsProvider.getCredentials();
     }
@@ -44,6 +44,13 @@ public class AWSAuthentication implements Authentication {
 
         signer.sign(new URLConnectionSignableRequest(urlConnection, body), credentials);
     }
+    
+    private String getCurrentRegion() {
+		if(Regions.getCurrentRegion() != null) {
+			return Regions.getCurrentRegion().getName();
+		}
+		return null;
+	}
 
     /**
      * Wrapper for signing a HttpURLConnection


### PR DESCRIPTION
Hello,
I was trying to use AWSAuthentication to connect a EC2 instance with Amazon ElasticSearch instance. but I was getting this error while trying to start the app :

`com.amazonaws.SdkClientException: Unable to find a region via the region provider chain.
`

After debugging, the Region was null.

I Fixed the AWSAuthentication in order to get the default region of the server.

I created an Issue too for the matter : https://github.com/internetitem/logback-elasticsearch-appender/issues/70

with this fix, it gets the correct Region.