### PR TITLE
Properly dispose streams

### DIFF
--- a/src/main/java/com/internetitem/logback/elasticsearch/writer/ElasticsearchWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/writer/ElasticsearchWriter.java
@@ -72,10 +72,10 @@ public class ElasticsearchWriter implements SafeWriter {
 				settings.getAuthentication().addAuth(urlConnection, body);
 			}
 
-			Writer writer = new OutputStreamWriter(urlConnection.getOutputStream(), "UTF-8");
-			writer.write(body);
-			writer.flush();
-			writer.close();
+			try( Writer writer = new OutputStreamWriter(urlConnection.getOutputStream(), "UTF-8") ) {
+				writer.write(body);
+				writer.flush();
+			}
 
 			int rc = urlConnection.getResponseCode();
 			if (rc != 200) {
@@ -98,18 +98,18 @@ public class ElasticsearchWriter implements SafeWriter {
 	}
 
 	private static String slurpErrors(HttpURLConnection urlConnection) {
-		try {
-			InputStream stream = urlConnection.getErrorStream();
+		try( InputStream stream = urlConnection.getErrorStream() ) {
 			if (stream == null) {
 				return "<no data>";
 			}
 
 			StringBuilder builder = new StringBuilder();
-			InputStreamReader reader = new InputStreamReader(stream, "UTF-8");
-			char[] buf = new char[2048];
-			int numRead;
-			while ((numRead = reader.read(buf)) > 0) {
-				builder.append(buf, 0, numRead);
+			try( InputStreamReader reader = new InputStreamReader(stream, "UTF-8") ) {
+				char[] buf = new char[2048];
+				int numRead;
+				while ((numRead = reader.read(buf)) > 0) {
+					builder.append(buf, 0, numRead);
+				}
 			}
 			return builder.toString();
 		} catch (Exception e) {


### PR DESCRIPTION
Some streams seem to leak resources (for example when `writer.write` throws an error).

In this case the `.close` is never called and leaks memory.