### PR TITLE
Implement various fixes and new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ In your `logback.xml`:
             <maxMessageSize>100</maxMessageSize> <!-- optional (default -1 -->
             <authentication class="com.internetitem.logback.elasticsearch.config.BasicAuthentication" /> <!-- optional -->
             <objectSerialization>true</objectSerialization> <!-- optional (default false) -->
+            <keyPrefix>data.</keyPrefix> <!-- optional (default None) -->
             <properties>
                 <property>
                     <name>host</name>
@@ -112,6 +113,7 @@ Configuration Reference
  * `maxMessageSize` (optional, default -1): If set to a number greater than 0, truncate messages larger than this length, then append "`..`" to denote that the message was truncated
  * `authentication` (optional): Add the ability to send authentication headers (see below)
  * `objectSerialization` (optional): specifies whether to use POJO to JSON serialization 
+ * `keyPrefix` (optional): objects logged within a message will also be logged separately with this prefix added  
 
 The fields `@timestamp` and `message` are always sent and can not currently be configured. Additional fields can be sent by adding `<property>` elements to the `<properties>` set.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ In your `logback.xml`:
             <includeMdc>false</includeMdc> <!-- optional (default false) -->
             <maxMessageSize>100</maxMessageSize> <!-- optional (default -1 -->
             <authentication class="com.internetitem.logback.elasticsearch.config.BasicAuthentication" /> <!-- optional -->
+            <objectSerialization>true</objectSerialization> <!-- optional (default false) -->
             <properties>
                 <property>
                     <name>host</name>
@@ -110,6 +111,7 @@ Configuration Reference
  * `includeMdc` (optional, default false): If set to `true`, then all [MDC](http://www.slf4j.org/api/org/slf4j/MDC.html) values will be mapped to properties on the JSON payload.
  * `maxMessageSize` (optional, default -1): If set to a number greater than 0, truncate messages larger than this length, then append "`..`" to denote that the message was truncated
  * `authentication` (optional): Add the ability to send authentication headers (see below)
+ * `objectSerialization` (optional): specifies whether to use POJO to JSON serialization 
 
 The fields `@timestamp` and `message` are always sent and can not currently be configured. Additional fields can be sent by adding `<property>` elements to the `<properties>` set.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ In your `logback.xml`:
             <authentication class="com.internetitem.logback.elasticsearch.config.BasicAuthentication" /> <!-- optional -->
             <objectSerialization>true</objectSerialization> <!-- optional (default false) -->
             <keyPrefix>data.</keyPrefix> <!-- optional (default None) -->
+            
             <properties>
                 <property>
                     <name>host</name>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
             <version>2.8.0</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.8.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
             <version>1.11.31</version>
@@ -84,6 +89,12 @@
             <artifactId>mockito-all</artifactId>
             <version>1.10.19</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>6.3</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchAppender.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchAppender.java
@@ -22,11 +22,27 @@ public abstract class AbstractElasticsearchAppender<T> extends UnsynchronizedApp
 	public AbstractElasticsearchAppender() {
 		this.settings = new Settings();
 		this.headers = new HttpRequestHeaders();
+		registerShutdownHook();
 	}
 
     public AbstractElasticsearchAppender(Settings settings) {
         this.settings = settings;
+		registerShutdownHook();
     }
+
+    private void registerShutdownHook() {
+		Runtime.getRuntime().addShutdownHook(new Thread(new ShutdownHook()));
+	}
+
+	private class ShutdownHook implements Runnable {
+		@Override
+		public void run() {
+			stop();
+			if(publisher != null) {
+				publisher.close();
+			}
+		}
+	}
 
 	@Override
 	public void start() {
@@ -138,4 +154,13 @@ public abstract class AbstractElasticsearchAppender<T> extends UnsynchronizedApp
     public void setMaxMessageSize(int maxMessageSize) {
     	settings.setMaxMessageSize(maxMessageSize);
 	}
+
+	public void setKeyPrefix(String keyPrefix) {
+		settings.setKeyPrefix(keyPrefix);
+	}
+
+	public void setObjectSerialization(boolean objectSerialization) {
+		settings.setObjectSerialization(objectSerialization);
+	}
+
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/StructuredArgsElasticsearchAppender.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/StructuredArgsElasticsearchAppender.java
@@ -1,0 +1,21 @@
+package com.internetitem.logback.elasticsearch;
+
+import com.internetitem.logback.elasticsearch.config.Settings;
+
+import java.io.IOException;
+
+public class StructuredArgsElasticsearchAppender extends ElasticsearchAppender {
+
+    public StructuredArgsElasticsearchAppender() {
+    }
+
+    public StructuredArgsElasticsearchAppender(Settings settings) {
+        super(settings);
+    }
+
+    protected StructuredArgsElasticsearchPublisher buildElasticsearchPublisher() throws IOException {
+        return new StructuredArgsElasticsearchPublisher(this.getContext(), this.errorReporter, this.settings,
+                this.elasticsearchProperties, this.headers);
+    }
+
+}

--- a/src/main/java/com/internetitem/logback/elasticsearch/StructuredArgsElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/StructuredArgsElasticsearchPublisher.java
@@ -1,0 +1,67 @@
+package com.internetitem.logback.elasticsearch;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Context;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.internetitem.logback.elasticsearch.config.ElasticsearchProperties;
+import com.internetitem.logback.elasticsearch.config.HttpRequestHeaders;
+import com.internetitem.logback.elasticsearch.config.Settings;
+import com.internetitem.logback.elasticsearch.util.ErrorReporter;
+import net.logstash.logback.marker.ObjectAppendingMarker;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+public class StructuredArgsElasticsearchPublisher extends ClassicElasticsearchPublisher {
+    private String keyPrefix;
+    private Field field;
+    private ErrorReporter errorReporter;
+
+    public StructuredArgsElasticsearchPublisher(Context context, ErrorReporter errorReporter, Settings settings, ElasticsearchProperties properties,
+                                                HttpRequestHeaders headers) throws IOException {
+        super(context, errorReporter, settings, properties, headers);
+
+        this.errorReporter = errorReporter;
+
+        keyPrefix = "";
+        if(settings != null && settings.getKeyPrefix() != null) {
+            keyPrefix = settings.getKeyPrefix();
+        }
+
+        try {
+            field = ObjectAppendingMarker.class.getDeclaredField("object");
+            field.setAccessible(true);
+        } catch (NoSuchFieldException e) {
+            // message will be logged without object
+            errorReporter.logError("error in logging with object serialization", e);
+        }
+    }
+
+    protected void serializeCommonFields(JsonGenerator gen, ILoggingEvent event) throws IOException {
+        super.serializeCommonFields(gen, event);
+
+        if(event.getArgumentArray() != null) {
+            Object[] eventArgs = event.getArgumentArray();
+            for(Object eventArg:eventArgs) {
+                if(eventArg instanceof ObjectAppendingMarker) {
+                    ObjectAppendingMarker marker = (ObjectAppendingMarker) eventArg;
+                    if(field != null && settings != null && settings.isObjectSerialization() &&
+                            marker.getFieldValue().toString().contains("@")) {
+                        try {
+                            Object obj = field.get(marker);
+                            if(obj != null) {
+                                gen.writeObjectField(keyPrefix + marker.getFieldName(), obj);
+                            }
+                        } catch (IllegalAccessException e) {
+                            // message will be logged without object
+                            errorReporter.logError("error in logging with object serialization", e);
+                        }
+                    }
+                    else
+                        gen.writeObjectField(keyPrefix + marker.getFieldName(), marker.getFieldValue());
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/Settings.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/Settings.java
@@ -23,6 +23,8 @@ public class Settings {
 	private int maxQueueSize = 100 * 1024 * 1024;
 	private Authentication authentication;
 	private int maxMessageSize = -1;
+	private String keyPrefix;
+	private boolean objectSerialization;
 
 	public String getIndex() {
 		return index;
@@ -162,4 +164,21 @@ public class Settings {
 	public void setMaxMessageSize(int maxMessageSize) {
 		this.maxMessageSize = maxMessageSize;
 	}
+
+	public String getKeyPrefix() {
+		return this.keyPrefix;
+	}
+
+	public void setKeyPrefix(String keyPrefix) {
+		this.keyPrefix = keyPrefix;
+	}
+
+	public boolean isObjectSerialization() {
+		return objectSerialization;
+	}
+
+	public void setObjectSerialization(boolean objectSerialization) {
+		this.objectSerialization = objectSerialization;
+	}
+
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/writer/ElasticsearchWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/writer/ElasticsearchWriter.java
@@ -105,18 +105,18 @@ public class ElasticsearchWriter implements SafeWriter {
 	}
 
 	private static String slurpErrors(HttpURLConnection urlConnection) {
-		try {
-			InputStream stream = urlConnection.getErrorStream();
+		try (InputStream stream = urlConnection.getErrorStream()) {
 			if (stream == null) {
 				return "<no data>";
 			}
 
 			StringBuilder builder = new StringBuilder();
-			InputStreamReader reader = new InputStreamReader(stream, "UTF-8");
-			char[] buf = new char[2048];
-			int numRead;
-			while ((numRead = reader.read(buf)) > 0) {
-				builder.append(buf, 0, numRead);
+			try(InputStreamReader reader = new InputStreamReader(stream, "UTF-8")) {
+				char[] buf = new char[2048];
+				int numRead;
+				while ((numRead = reader.read(buf)) > 0) {
+					builder.append(buf, 0, numRead);
+				}
 			}
 			return builder.toString();
 		} catch (Exception e) {


### PR DESCRIPTION
- Clear the log buffer so that when the program is about to finish pending messages are sent to Elasticsearch.
- Add the capability of transmitting compressed messages.
- Add the capability of logging Java POJOs as JSON.
- Whenever a key-value parameter is logged as part of a message “serialized document with docOid=1234”, we log it outside as well, as other appenders do “serialized document with docOid=1234” + “docOid=1234”.
- Allow the users to add a keyPrefix, so we would have prefix.docOid=1234.
- Add closing resources following https://github.com/internetitem/logback-elasticsearch-appender/pull/72/commits/6a5bc60aea6dfa501383a07464311272703a4dcf
- Update readme

These changes were sponsored by IGT (https://www.igt.com/)