### PR TITLE
allow overriding ElasticsearchWriter for those who want a non restrictive https mode

### DIFF
--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
@@ -69,7 +69,7 @@ public abstract class AbstractElasticsearchPublisher<T> implements Runnable {
 		this.propertySerializer = new PropertySerializer();
 	}
 
-	private static ElasticsearchOutputAggregator configureOutputAggregator(Settings settings, ErrorReporter errorReporter, HttpRequestHeaders httpRequestHeaders)  {
+	protected static ElasticsearchOutputAggregator configureOutputAggregator(Settings settings, ErrorReporter errorReporter, HttpRequestHeaders httpRequestHeaders)  {
 		ElasticsearchOutputAggregator spigot = new ElasticsearchOutputAggregator(settings, errorReporter);
 
 		if (settings.isLogsToStderr()) {

--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
@@ -69,7 +69,7 @@ public abstract class AbstractElasticsearchPublisher<T> implements Runnable {
 		this.propertySerializer = new PropertySerializer();
 	}
 
-	protected static ElasticsearchOutputAggregator configureOutputAggregator(Settings settings, ErrorReporter errorReporter, HttpRequestHeaders httpRequestHeaders)  {
+	protected ElasticsearchOutputAggregator configureOutputAggregator(Settings settings, ErrorReporter errorReporter, HttpRequestHeaders httpRequestHeaders)  {
 		ElasticsearchOutputAggregator spigot = new ElasticsearchOutputAggregator(settings, errorReporter);
 
 		if (settings.isLogsToStderr()) {

--- a/src/main/java/com/internetitem/logback/elasticsearch/writer/ElasticsearchWriter.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/writer/ElasticsearchWriter.java
@@ -97,7 +97,7 @@ public class ElasticsearchWriter implements SafeWriter {
 		return sendBuffer.length() != 0;
 	}
 
-	private static String slurpErrors(HttpURLConnection urlConnection) {
+	protected  String slurpErrors(HttpURLConnection urlConnection) {
 		try {
 			InputStream stream = urlConnection.getErrorStream();
 			if (stream == null) {
@@ -117,4 +117,30 @@ public class ElasticsearchWriter implements SafeWriter {
 		}
 	}
 
+    public StringBuilder getSendBuffer() {
+        return sendBuffer;
+    }
+
+    public Settings getSettings() {
+        return settings;
+    }
+
+    public Collection<HttpRequestHeader> getHeaderList() {
+        return headerList;
+    }
+
+    public ErrorReporter getErrorReporter() {
+        return errorReporter;
+    }
+
+    public boolean isBufferExceeded() {
+        return bufferExceeded;
+    }
+
+    public void setBufferExceeded(boolean bufferExceeded) {
+        this.bufferExceeded = bufferExceeded;
+    }
+
+        
+        
 }


### PR DESCRIPTION
Hi,

Currently it's hard to make elasticsearch-appender work with https. Of course there is always the solution to register certificates into jvm but it's not handy especially if you have certificates with only 1 year validity, then you'd need many things to manage. If you let this method protected, people can override this method, override the ElasticsearchWriter, so when they want to trust all certificates, they can do it.

Best regards