### PR TITLE
rename property tag since it conflicts with built-in tag on logback >= 1.3

### DIFF
--- a/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AbstractElasticsearchPublisher.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.internetitem.logback.elasticsearch.config.ElasticsearchProperties;
 import com.internetitem.logback.elasticsearch.config.HttpRequestHeaders;
-import com.internetitem.logback.elasticsearch.config.Property;
+import com.internetitem.logback.elasticsearch.config.EsProperty;
 import com.internetitem.logback.elasticsearch.config.Settings;
 import com.internetitem.logback.elasticsearch.util.AbstractPropertyAndEncoder;
 import com.internetitem.logback.elasticsearch.util.ErrorReporter;
@@ -63,7 +63,7 @@ public abstract class AbstractElasticsearchPublisher<T> implements Runnable {
 		this.jf.setRootValueSeparator(null);
 		this.jsonGenerator = jf.createGenerator(outputAggregator);
 
-		this.indexPattern = buildPropertyAndEncoder(context, new Property("<index>", settings.getIndex(), false));
+		this.indexPattern = buildPropertyAndEncoder(context, new EsProperty("<index>", settings.getIndex(), false));
 		this.propertyList = generatePropertyList(context, properties);
 
 		this.propertySerializer = new PropertySerializer();
@@ -90,14 +90,14 @@ public abstract class AbstractElasticsearchPublisher<T> implements Runnable {
 	private List<AbstractPropertyAndEncoder<T>> generatePropertyList(Context context, ElasticsearchProperties properties) {
 		List<AbstractPropertyAndEncoder<T>> list = new ArrayList<AbstractPropertyAndEncoder<T>>();
 		if (properties != null) {
-			for (Property property : properties.getProperties()) {
+			for (EsProperty property : properties.getProperties()) {
 				list.add(buildPropertyAndEncoder(context, property));
 			}
 		}
 		return list;
 	}
 
-	protected abstract AbstractPropertyAndEncoder<T> buildPropertyAndEncoder(Context context, Property property);
+	protected abstract AbstractPropertyAndEncoder<T> buildPropertyAndEncoder(Context context, EsProperty property);
 
 	public void addEvent(T event) {
 		if (!outputAggregator.hasOutputs()) {

--- a/src/main/java/com/internetitem/logback/elasticsearch/AccessElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/AccessElasticsearchPublisher.java
@@ -7,7 +7,7 @@ import ch.qos.logback.core.Context;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.internetitem.logback.elasticsearch.config.ElasticsearchProperties;
 import com.internetitem.logback.elasticsearch.config.HttpRequestHeaders;
-import com.internetitem.logback.elasticsearch.config.Property;
+import com.internetitem.logback.elasticsearch.config.EsProperty;
 import com.internetitem.logback.elasticsearch.config.Settings;
 import com.internetitem.logback.elasticsearch.util.AbstractPropertyAndEncoder;
 import com.internetitem.logback.elasticsearch.util.AccessPropertyAndEncoder;
@@ -20,7 +20,7 @@ public class AccessElasticsearchPublisher extends AbstractElasticsearchPublisher
 	}
 
 	@Override
-	protected AbstractPropertyAndEncoder<IAccessEvent> buildPropertyAndEncoder(Context context, Property property) {
+	protected AbstractPropertyAndEncoder<IAccessEvent> buildPropertyAndEncoder(Context context, EsProperty property) {
 		return new AccessPropertyAndEncoder(property, context);
 	}
 

--- a/src/main/java/com/internetitem/logback/elasticsearch/ClassicElasticsearchPublisher.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/ClassicElasticsearchPublisher.java
@@ -8,7 +8,7 @@ import ch.qos.logback.core.Context;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.internetitem.logback.elasticsearch.config.ElasticsearchProperties;
 import com.internetitem.logback.elasticsearch.config.HttpRequestHeaders;
-import com.internetitem.logback.elasticsearch.config.Property;
+import com.internetitem.logback.elasticsearch.config.EsProperty;
 import com.internetitem.logback.elasticsearch.config.Settings;
 import com.internetitem.logback.elasticsearch.util.AbstractPropertyAndEncoder;
 import com.internetitem.logback.elasticsearch.util.ClassicPropertyAndEncoder;
@@ -21,7 +21,7 @@ public class ClassicElasticsearchPublisher extends AbstractElasticsearchPublishe
     }
 
     @Override
-    protected AbstractPropertyAndEncoder<ILoggingEvent> buildPropertyAndEncoder(Context context, Property property) {
+    protected AbstractPropertyAndEncoder<ILoggingEvent> buildPropertyAndEncoder(Context context, EsProperty property) {
         return new ClassicPropertyAndEncoder(property, context);
     }
 

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/ElasticsearchProperties.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/ElasticsearchProperties.java
@@ -5,17 +5,17 @@ import java.util.List;
 
 public class ElasticsearchProperties {
 
-	private List<Property> properties;
+	private List<EsProperty> properties;
 
 	public ElasticsearchProperties() {
-		this.properties = new ArrayList<Property>();
+		this.properties = new ArrayList<EsProperty>();
 	}
 
-	public List<Property> getProperties() {
+	public List<EsProperty> getProperties() {
 		return properties;
 	}
 
-	public void addProperty(Property property) {
+	public void addEsProperty(EsProperty property) {
 		properties.add(property);
 	}
 

--- a/src/main/java/com/internetitem/logback/elasticsearch/config/EsProperty.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/config/EsProperty.java
@@ -1,6 +1,6 @@
 package com.internetitem.logback.elasticsearch.config;
 
-public class Property {
+public class EsProperty {
 	private String name;
 	private String value;
 	private boolean allowEmpty;
@@ -10,10 +10,10 @@ public class Property {
 		STRING, INT, FLOAT, BOOLEAN
 	}
 
-	public Property() {
+	public EsProperty() {
 	}
 
-	public Property(String name, String value, boolean allowEmpty) {
+	public EsProperty(String name, String value, boolean allowEmpty) {
 		this.name = name;
 		this.value = value;
 		this.allowEmpty = allowEmpty;

--- a/src/main/java/com/internetitem/logback/elasticsearch/util/AbstractPropertyAndEncoder.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/util/AbstractPropertyAndEncoder.java
@@ -2,13 +2,13 @@ package com.internetitem.logback.elasticsearch.util;
 
 import ch.qos.logback.core.Context;
 import ch.qos.logback.core.pattern.PatternLayoutBase;
-import com.internetitem.logback.elasticsearch.config.Property;
+import com.internetitem.logback.elasticsearch.config.EsProperty;
 
 public abstract class AbstractPropertyAndEncoder<T> {
-	private Property property;
+	private EsProperty property;
 	private PatternLayoutBase<T> layout;
 
-	public AbstractPropertyAndEncoder(Property property, Context context) {
+	public AbstractPropertyAndEncoder(EsProperty property, Context context) {
 		this.property = property;
 
 		this.layout = getLayout();
@@ -32,7 +32,7 @@ public abstract class AbstractPropertyAndEncoder<T> {
 		return property.isAllowEmpty();
 	}
 
-	public Property.Type getType() {
+	public EsProperty.Type getType() {
 		return property.getType();
 	}
 }

--- a/src/main/java/com/internetitem/logback/elasticsearch/util/AccessPropertyAndEncoder.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/util/AccessPropertyAndEncoder.java
@@ -4,11 +4,11 @@ import ch.qos.logback.access.spi.IAccessEvent;
 import ch.qos.logback.access.PatternLayout;
 import ch.qos.logback.core.Context;
 import ch.qos.logback.core.pattern.PatternLayoutBase;
-import com.internetitem.logback.elasticsearch.config.Property;
+import com.internetitem.logback.elasticsearch.config.EsProperty;
 
 public class AccessPropertyAndEncoder extends AbstractPropertyAndEncoder<IAccessEvent> {
 
-    public AccessPropertyAndEncoder(Property property, Context context) {
+    public AccessPropertyAndEncoder(EsProperty property, Context context) {
         super(property, context);
     }
 

--- a/src/main/java/com/internetitem/logback/elasticsearch/util/ClassicPropertyAndEncoder.java
+++ b/src/main/java/com/internetitem/logback/elasticsearch/util/ClassicPropertyAndEncoder.java
@@ -4,11 +4,11 @@ import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Context;
 import ch.qos.logback.core.pattern.PatternLayoutBase;
-import com.internetitem.logback.elasticsearch.config.Property;
+import com.internetitem.logback.elasticsearch.config.EsProperty;
 
 public class ClassicPropertyAndEncoder extends AbstractPropertyAndEncoder<ILoggingEvent> {
 
-    public ClassicPropertyAndEncoder(Property property, Context context) {
+    public ClassicPropertyAndEncoder(EsProperty property, Context context) {
         super(property, context);
     }
 

--- a/src/test/java/com/internetitem/logback/elasticsearch/EsPropertySerializerTest.java
+++ b/src/test/java/com/internetitem/logback/elasticsearch/EsPropertySerializerTest.java
@@ -3,7 +3,7 @@ package com.internetitem.logback.elasticsearch;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Context;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.internetitem.logback.elasticsearch.config.Property;
+import com.internetitem.logback.elasticsearch.config.EsProperty;
 import com.internetitem.logback.elasticsearch.util.ClassicPropertyAndEncoder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
-public class PropertySerializerTest {
+public class EsPropertySerializerTest {
     @Mock
     private Context context;
 
@@ -30,21 +30,21 @@ public class PropertySerializerTest {
     @Test
     public void should_default_to_string_type() throws Exception {
         // given
-        Property property = new Property();
+        EsProperty property = new EsProperty();
         property.setValue("propertyValue");
 
         // when
         propertySerializer.serializeProperty(jsonGenerator, loggingEvent, new ClassicPropertyAndEncoder(property, context));
 
         // then
-        assertThat(property.getType(), is(Property.Type.STRING));
+        assertThat(property.getType(), is(EsProperty.Type.STRING));
         verify(jsonGenerator).writeObject("propertyValue");
     }
 
     @Test
     public void should_serialize_int_as_number() throws Exception {
         // given
-        Property property = new Property();
+        EsProperty property = new EsProperty();
         property.setValue("123");
         property.setType("int");
 
@@ -58,7 +58,7 @@ public class PropertySerializerTest {
     @Test
     public void should_serialize_object_when_invalid_int() throws Exception {
         // given
-        Property property = new Property();
+        EsProperty property = new EsProperty();
         property.setValue("A123Z");
         property.setType("int");
 
@@ -72,7 +72,7 @@ public class PropertySerializerTest {
     @Test
     public void should_serialize_float_as_number() throws Exception {
         // given
-        Property property = new Property();
+        EsProperty property = new EsProperty();
         property.setValue("12.30");
         property.setType("float");
 
@@ -86,7 +86,7 @@ public class PropertySerializerTest {
     @Test
     public void should_serialize_object_when_invalid_float() throws Exception {
         // given
-        Property property = new Property();
+        EsProperty property = new EsProperty();
         property.setValue("A12.30Z");
         property.setType("float");
 
@@ -100,7 +100,7 @@ public class PropertySerializerTest {
     @Test
     public void should_serialize_true_as_boolean() throws Exception {
         // given
-        Property property = new Property();
+        EsProperty property = new EsProperty();
         property.setValue("true");
         property.setType("boolean");
 
@@ -114,7 +114,7 @@ public class PropertySerializerTest {
     @Test
     public void should_serialize_object_when_invalid_boolean() throws Exception {
         // given
-        Property property = new Property();
+        EsProperty property = new EsProperty();
         property.setValue("AtrueZ");
         property.setType("boolean");
 
@@ -128,7 +128,7 @@ public class PropertySerializerTest {
     @Test
     public void should_serialize_object_when_invalid_type() throws Exception {
         // given
-        Property property = new Property();
+        EsProperty property = new EsProperty();
         property.setValue("value");
         property.setType("invalidType");
 


### PR DESCRIPTION
maybe there's a better fix but this solves the issue

logback output without the fix:
```6:27:57,749 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [com.internetitem.logback.elasticsearch.ElasticsearchAppender]
16:27:57,755 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [com.internetitem.logback.elasticsearch.config.ElasticsearchProperties] for [properties] property
16:27:57,755 |-ERROR in ch.qos.logback.core.model.processor.PropertyModelHandler - In <property> element, either the "file" attribute alone, or the "resource" element alone, or both the "name" and "value" attributes must be set.
16:27:57,756 |-WARN in ch.qos.logback.core.model.processor.ImplicitModelHandler - Ignoring unknown property [name] in [com.internetitem.logback.elasticsearch.config.ElasticsearchProperties]
16:27:57,756 |-WARN in ch.qos.logback.core.model.processor.ImplicitModelHandler - Ignoring unknown property [value] in [com.internetitem.logback.elasticsearch.config.ElasticsearchProperties]
16:27:57,756 |-WARN in ch.qos.logback.core.model.processor.ImplicitModelHandler - Ignoring unknown property [allowEmpty] in [com.internetitem.logback.elasticsearch.config.ElasticsearchProperties]```